### PR TITLE
feat: add `@material-tech/alloy` umbrella package

### DIFF
--- a/packages/alloy/package.json
+++ b/packages/alloy/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@material-tech/alloy",
+  "type": "module",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./dist/index.js",
+    "./node-stream": "./dist/node-stream.js",
+    "./web-stream": "./dist/web-stream.js",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown"
+  },
+  "dependencies": {
+    "@material-tech/alloy-core": "workspace:^",
+    "@material-tech/alloy-indicators": "workspace:^",
+    "@material-tech/alloy-adapters": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:build",
+    "tsdown": "catalog:build",
+    "typescript": "catalog:build"
+  }
+}

--- a/packages/alloy/src/index.ts
+++ b/packages/alloy/src/index.ts
@@ -1,0 +1,3 @@
+export { batch, batchProcess } from '@material-tech/alloy-adapters/batch'
+export * from '@material-tech/alloy-core'
+export * from '@material-tech/alloy-indicators'

--- a/packages/alloy/src/node-stream.ts
+++ b/packages/alloy/src/node-stream.ts
@@ -1,0 +1,1 @@
+export * from '@material-tech/alloy-adapters/node-stream'

--- a/packages/alloy/src/web-stream.ts
+++ b/packages/alloy/src/web-stream.ts
@@ -1,0 +1,1 @@
+export * from '@material-tech/alloy-adapters/web-stream'

--- a/packages/alloy/tsconfig.json
+++ b/packages/alloy/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@material-tech/alloy-core": ["../core/src/index.ts"],
+      "@material-tech/alloy-indicators": ["../indicators/src/index.ts"],
+      "@material-tech/alloy-adapters": ["../adapters/src/index.ts"],
+      "@material-tech/alloy-adapters/*": ["../adapters/src/*.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/alloy/tsdown.config.ts
+++ b/packages/alloy/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    'index': './src/index.ts',
+    'node-stream': './src/node-stream.ts',
+    'web-stream': './src/web-stream.ts',
+  },
+  target: 'es2020',
+  clean: true,
+  dts: true,
+  exports: true,
+  sourcemap: true,
+  platform: 'neutral',
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,28 @@ importers:
         specifier: catalog:test
         version: 4.0.18(@types/node@25.2.3)(jiti@2.5.1)(yaml@2.8.2)
 
+  packages/alloy:
+    dependencies:
+      '@material-tech/alloy-adapters':
+        specifier: workspace:^
+        version: link:../adapters
+      '@material-tech/alloy-core':
+        specifier: workspace:^
+        version: link:../core
+      '@material-tech/alloy-indicators':
+        specifier: workspace:^
+        version: link:../indicators
+    devDependencies:
+      '@types/node':
+        specifier: catalog:build
+        version: 25.2.3
+      tsdown:
+        specifier: catalog:build
+        version: 0.20.3(synckit@0.11.11)(typescript@5.9.3)
+      typescript:
+        specifier: catalog:build
+        version: 5.9.3
+
   packages/core:
     dependencies:
       defu:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
       "@material-tech/alloy-core": ["./packages/core/src/index.ts"],
       "@material-tech/alloy-indicators": ["./packages/indicators/src/index.ts"],
       "@material-tech/alloy-adapters": ["./packages/adapters/src/index.ts"],
-      "@material-tech/alloy-adapters/*": ["./packages/adapters/src/*.ts"]
+      "@material-tech/alloy-adapters/*": ["./packages/adapters/src/*.ts"],
+      "@material-tech/alloy": ["./packages/alloy/src/index.ts"],
+      "@material-tech/alloy/*": ["./packages/alloy/src/*.ts"]
     }
   },
   "include": ["packages/*/src/**/*.ts"]


### PR DESCRIPTION
## Summary

- Add `@material-tech/alloy` as a unified entry point package that re-exports core, indicators, and batch adapter
- Platform-specific stream adapters available via subpath exports (`@material-tech/alloy/node-stream`, `@material-tech/alloy/web-stream`)
- Update root `tsconfig.json` with path mappings for the new package

## Usage

```typescript
// Single import for all platform-agnostic APIs
import { collect, sma, rsi, batch } from '@material-tech/alloy'

// Platform-specific adapters via subpath
import { toNodeStream } from '@material-tech/alloy/node-stream'
import { toWebStream } from '@material-tech/alloy/web-stream'
```

## Test plan

- [x] `pnpm install` — workspace packages linked correctly
- [x] `pnpm build` — all packages (including new one) build successfully
- [x] `pnpm test --run` — all 76 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)