### PR TITLE
feat: add `@material-tech/alloy-strategies` package

### DIFF
--- a/packages/alloy/package.json
+++ b/packages/alloy/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@material-tech/alloy-core": "workspace:^",
     "@material-tech/alloy-indicators": "workspace:^",
+    "@material-tech/alloy-strategies": "workspace:^",
     "@material-tech/alloy-adapters": "workspace:^"
   },
   "devDependencies": {

--- a/packages/alloy/src/index.ts
+++ b/packages/alloy/src/index.ts
@@ -1,3 +1,4 @@
 export { batch, batchProcess } from '@material-tech/alloy-adapters/batch'
 export * from '@material-tech/alloy-core'
 export * from '@material-tech/alloy-indicators'
+export * from '@material-tech/alloy-strategies'

--- a/packages/alloy/tsconfig.json
+++ b/packages/alloy/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@material-tech/alloy-core": ["../core/src/index.ts"],
       "@material-tech/alloy-indicators": ["../indicators/src/index.ts"],
+      "@material-tech/alloy-strategies": ["../strategies/src/index.ts"],
       "@material-tech/alloy-adapters": ["../adapters/src/index.ts"],
       "@material-tech/alloy-adapters/*": ["../adapters/src/*.ts"]
     }

--- a/packages/strategies/package.json
+++ b/packages/strategies/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@material-tech/alloy-strategies",
+  "type": "module",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@material-tech/alloy-core": "workspace:^",
+    "@material-tech/alloy-indicators": "workspace:^",
+    "defu": "catalog:runtime",
+    "dnum": "catalog:runtime"
+  },
+  "devDependencies": {
+    "vite-tsconfig-paths": "catalog:test",
+    "vitest": "catalog:test"
+  }
+}

--- a/packages/strategies/src/base.ts
+++ b/packages/strategies/src/base.ts
@@ -1,0 +1,80 @@
+import type { BaseStrategyOptions, KlineData, Processor, StrategyContext, StrategyFactory, StrategyGenerator, StrategySignal } from './types'
+import { defu } from 'defu'
+
+/**
+ * A fixed-capacity ring buffer with O(1) push and O(n) snapshot.
+ */
+function createRingBuffer<T>(capacity: number) {
+  const buf: T[] = Array.from({ length: capacity })
+  let head = 0
+  let size = 0
+
+  return {
+    push(item: T) {
+      buf[head] = item
+      head = (head + 1) % capacity
+      if (size < capacity)
+        size++
+    },
+    toArray(): readonly T[] {
+      if (size < capacity) {
+        return buf.slice(0, size)
+      }
+      // head points to the oldest element when buffer is full
+      return [...buf.slice(head), ...buf.slice(0, head)]
+    },
+    get size() {
+      return size
+    },
+  }
+}
+
+/**
+ * Create a generator-based strategy from a strategy factory.
+ *
+ * Mirrors `createSignal` from core, but manages a rolling window of bars
+ * and constructs a `StrategyContext` for each evaluation.
+ *
+ * The returned generator is fully compatible with `IndicatorGenerator<KlineData, StrategySignal, Opts>`,
+ * so all existing adapters (batch, node-stream, web-stream) work out of the box.
+ */
+export function createStrategy<Opts extends BaseStrategyOptions>(
+  factory: StrategyFactory<Opts>,
+  defaultOptions: Opts,
+): StrategyGenerator<Opts> {
+  function buildProcessor(options?: Partial<Opts>): Processor<KlineData, StrategySignal> {
+    const opt = defu(options, defaultOptions) as Required<Opts>
+    const ring = createRingBuffer<KlineData>(opt.windowSize)
+    const process = factory(opt)
+    let index = 0
+    return (bar: KlineData) => {
+      ring.push(bar)
+      const ctx: StrategyContext = { bar, bars: ring.toArray(), index }
+      const signal = process(ctx)
+      index++
+      return signal
+    }
+  }
+
+  function* generator(
+    source: Iterable<KlineData>,
+    options?: Partial<Opts>,
+  ): Generator<StrategySignal, void, unknown> {
+    const process = buildProcessor(options)
+    for (const bar of source) {
+      yield process(bar)
+    }
+  }
+
+  generator.create = (options?: Partial<Opts>): Processor<KlineData, StrategySignal> => {
+    return buildProcessor(options)
+  }
+
+  Object.defineProperty(generator, 'defaultOptions', {
+    get() {
+      return defu(defaultOptions)
+    },
+  })
+
+  return generator as StrategyGenerator<Opts>
+}

--- a/packages/strategies/src/builtin/goldenCross.ts
+++ b/packages/strategies/src/builtin/goldenCross.ts
@@ -1,0 +1,75 @@
+import type { Dnum, Numberish } from 'dnum'
+import type { BaseStrategyOptions, StrategySignal } from '../types'
+import { sma } from '@material-tech/alloy-indicators'
+import { from, gt, toNumber } from 'dnum'
+import { createStrategy } from '../base'
+
+export interface GoldenCrossOptions extends BaseStrategyOptions {
+  /** Fast SMA period */
+  fastPeriod: number
+  /** Slow SMA period */
+  slowPeriod: number
+  /** Stop-loss percentage (0–1), e.g. 0.02 = 2% */
+  stopLossPercent: number
+}
+
+export const defaultGoldenCrossOptions: GoldenCrossOptions = {
+  windowSize: 2,
+  fastPeriod: 50,
+  slowPeriod: 200,
+  stopLossPercent: 0.02,
+}
+
+/**
+ * Golden Cross / Death Cross Strategy
+ *
+ * Detects when a fast SMA crosses above (golden cross → long) or
+ * below (death cross → short) a slow SMA.
+ *
+ * - **Golden Cross**: fast SMA crosses above slow SMA → `long`
+ * - **Death Cross**: fast SMA crosses below slow SMA → `short`
+ * - Otherwise → `hold`
+ *
+ * Stop-loss is set as a percentage below/above the entry price.
+ */
+export const goldenCross = createStrategy(
+  ({ fastPeriod, slowPeriod, stopLossPercent }) => {
+    const fastSma = sma.create({ period: fastPeriod })
+    const slowSma = sma.create({ period: slowPeriod })
+    let prevFastAbove: boolean | undefined
+
+    return (ctx) => {
+      const close = ctx.bar.c as Numberish
+      const fast: Dnum = fastSma(close)
+      const slow: Dnum = slowSma(close)
+      const fastAbove = gt(fast, slow)
+      const price = toNumber(from(close, 18))
+
+      let signal: StrategySignal = { action: 'hold' }
+
+      if (prevFastAbove !== undefined) {
+        if (fastAbove && !prevFastAbove) {
+          signal = {
+            action: 'long',
+            stopLoss: price * (1 - stopLossPercent),
+            reason: 'Golden cross: fast SMA crossed above slow SMA',
+          }
+        }
+        else if (!fastAbove && prevFastAbove) {
+          signal = {
+            action: 'short',
+            stopLoss: price * (1 + stopLossPercent),
+            reason: 'Death cross: fast SMA crossed below slow SMA',
+          }
+        }
+      }
+
+      prevFastAbove = fastAbove
+
+      return signal
+    }
+  },
+  defaultGoldenCrossOptions,
+)
+
+export { goldenCross as goldenCrossStrategy }

--- a/packages/strategies/src/builtin/index.ts
+++ b/packages/strategies/src/builtin/index.ts
@@ -1,0 +1,2 @@
+export * from './goldenCross'
+export * from './rsiOversoldOverbought'

--- a/packages/strategies/src/builtin/rsiOversoldOverbought.ts
+++ b/packages/strategies/src/builtin/rsiOversoldOverbought.ts
@@ -1,0 +1,70 @@
+import type { Dnum, Numberish } from 'dnum'
+import type { BaseStrategyOptions, StrategySignal } from '../types'
+import { rsi } from '@material-tech/alloy-indicators'
+import { from, gt, lt } from 'dnum'
+import { createStrategy } from '../base'
+
+export interface RsiOversoldOverboughtOptions extends BaseStrategyOptions {
+  /** RSI calculation period */
+  period: number
+  /** RSI level above which the asset is considered overbought */
+  overboughtLevel: number
+  /** RSI level below which the asset is considered oversold */
+  oversoldLevel: number
+}
+
+export const defaultRsiOversoldOverboughtOptions: RsiOversoldOverboughtOptions = {
+  windowSize: 2,
+  period: 14,
+  overboughtLevel: 70,
+  oversoldLevel: 30,
+}
+
+/**
+ * RSI Oversold/Overbought Strategy
+ *
+ * Uses the Relative Strength Index to detect oversold and overbought conditions.
+ *
+ * - RSI crosses below `oversoldLevel` then back above → `long` (oversold reversal)
+ * - RSI crosses above `overboughtLevel` then back below → `short` (overbought reversal)
+ * - Otherwise → `hold`
+ */
+export const rsiOversoldOverbought = createStrategy(
+  ({ period, overboughtLevel, oversoldLevel }) => {
+    const rsiProc = rsi.create({ period })
+    let prevRsi: Dnum | undefined
+    const obLevel = from(overboughtLevel, 18)
+    const osLevel = from(oversoldLevel, 18)
+
+    return (ctx) => {
+      const close = ctx.bar.c as Numberish
+      const currentRsi = rsiProc(close)
+
+      let signal: StrategySignal = { action: 'hold' }
+
+      if (prevRsi !== undefined) {
+        // Oversold reversal: RSI was below oversoldLevel, now crosses above
+        if (lt(prevRsi, osLevel) && gt(currentRsi, osLevel)) {
+          signal = {
+            action: 'long',
+            reason: `RSI crossed above oversold level (${oversoldLevel})`,
+          }
+        }
+        // Overbought reversal: RSI was above overboughtLevel, now crosses below
+        else if (gt(prevRsi, obLevel) && lt(currentRsi, obLevel)) {
+          signal = {
+            action: 'short',
+            reason: `RSI crossed below overbought level (${overboughtLevel})`,
+          }
+        }
+      }
+
+      prevRsi = currentRsi
+
+      return signal
+    }
+  },
+  defaultRsiOversoldOverboughtOptions,
+)
+
+export { rsiOversoldOverbought as rsiOversoldOverboughtStrategy }

--- a/packages/strategies/src/index.ts
+++ b/packages/strategies/src/index.ts
@@ -1,0 +1,10 @@
+export { createStrategy } from './base'
+export * from './builtin'
+export type {
+  BaseStrategyOptions,
+  StrategyAction,
+  StrategyContext,
+  StrategyFactory,
+  StrategyGenerator,
+  StrategySignal,
+} from './types'

--- a/packages/strategies/src/types.ts
+++ b/packages/strategies/src/types.ts
@@ -1,0 +1,53 @@
+import type { IndicatorGenerator, KlineData, Processor } from '@material-tech/alloy-core'
+
+/**
+ * The action a strategy recommends.
+ */
+export type StrategyAction = 'long' | 'short' | 'close' | 'hold'
+
+/**
+ * Structured signal output from a strategy.
+ */
+export interface StrategySignal {
+  /** The recommended action */
+  action: StrategyAction
+  /** Position size as a fraction (0–1), defaults to 1 */
+  size?: number
+  /** Stop-loss price level */
+  stopLoss?: number
+  /** Take-profit price level */
+  takeProfit?: number
+  /** Human-readable reason for the signal */
+  reason?: string
+}
+
+/**
+ * Base options that every strategy must include.
+ */
+export interface BaseStrategyOptions {
+  /** Number of historical bars to keep in the rolling window */
+  windowSize: number
+}
+
+/**
+ * Context passed to the strategy evaluation function on each bar.
+ */
+export interface StrategyContext {
+  /** The current bar */
+  bar: KlineData
+  /** Historical bars in the rolling window (oldest first, includes current bar) */
+  bars: readonly KlineData[]
+  /** Zero-based index of the current bar since the strategy started */
+  index: number
+}
+
+/**
+ * A strategy generator — type alias ensuring compatibility with all existing adapters.
+ */
+export type StrategyGenerator<Opts extends BaseStrategyOptions>
+  = IndicatorGenerator<KlineData, StrategySignal, Opts>
+
+export type StrategyFactory<Opts extends BaseStrategyOptions>
+  = (opts: Required<Opts>) => (ctx: StrategyContext) => StrategySignal
+
+export type { KlineData, Processor }

--- a/packages/strategies/tests/base.spec.ts
+++ b/packages/strategies/tests/base.spec.ts
@@ -1,0 +1,157 @@
+import type { StrategySignal } from '@material-tech/alloy-strategies'
+import { collect } from '@material-tech/alloy-core'
+import { createStrategy } from '@material-tech/alloy-strategies'
+import { describe, expect, it } from 'vitest'
+
+function bar(c: number, h = c, l = c, o = c, v = 100) {
+  return { h, l, o, c, v }
+}
+
+describe('createStrategy', () => {
+  const hold: StrategySignal = { action: 'hold' }
+
+  const dummyStrategy = createStrategy(
+    () => (ctx) => {
+      if (ctx.index === 0)
+        return { action: 'long', reason: 'first bar' }
+      return hold
+    },
+    { windowSize: 3 },
+  )
+
+  it('should create a generator function with .create() and .defaultOptions', () => {
+    expect(dummyStrategy).toBeInstanceOf(Function)
+    expect(dummyStrategy.create).toBeInstanceOf(Function)
+    expect(dummyStrategy.defaultOptions).toEqual({ windowSize: 3 })
+  })
+
+  it('should yield strategy signals from source', () => {
+    const bars = [bar(1), bar(2), bar(3)]
+    const result = collect(dummyStrategy(bars))
+
+    expect(result).toEqual([
+      { action: 'long', reason: 'first bar' },
+      hold,
+      hold,
+    ])
+  })
+
+  it('should create independent processors via .create()', () => {
+    const counterStrategy = createStrategy(
+      () => {
+        let count = 0
+        return () => {
+          count++
+          return { action: 'hold' as const, reason: String(count) }
+        }
+      },
+      { windowSize: 2 },
+    )
+
+    const p1 = counterStrategy.create()
+    const p2 = counterStrategy.create()
+
+    expect(p1(bar(1)).reason).toBe('1')
+    expect(p1(bar(2)).reason).toBe('2')
+    expect(p2(bar(1)).reason).toBe('1') // independent state
+  })
+
+  it('should respect windowSize and limit bars in context', () => {
+    const windowCapture = createStrategy(
+      () => (ctx) => {
+        return { action: 'hold', reason: String(ctx.bars.length) }
+      },
+      { windowSize: 2 },
+    )
+
+    const bars = [bar(1), bar(2), bar(3), bar(4)]
+    const result = collect(windowCapture(bars))
+
+    expect(result.map(s => s.reason)).toEqual(['1', '2', '2', '2'])
+  })
+
+  it('should provide bars in oldest-first order', () => {
+    const barCapture = createStrategy(
+      () => (ctx) => {
+        const closes = ctx.bars.map(b => Number(b.c))
+        return { action: 'hold', reason: closes.join(',') }
+      },
+      { windowSize: 3 },
+    )
+
+    const bars = [bar(10), bar(20), bar(30), bar(40), bar(50)]
+    const result = collect(barCapture(bars))
+
+    expect(result[0].reason).toBe('10')
+    expect(result[1].reason).toBe('10,20')
+    expect(result[2].reason).toBe('10,20,30')
+    expect(result[3].reason).toBe('20,30,40') // oldest (10) dropped
+    expect(result[4].reason).toBe('30,40,50')
+  })
+
+  it('should increment index on each bar', () => {
+    const indexCapture = createStrategy(
+      () => (ctx) => {
+        return { action: 'hold', reason: String(ctx.index) }
+      },
+      { windowSize: 2 },
+    )
+
+    const bars = [bar(1), bar(2), bar(3)]
+    const result = collect(indexCapture(bars))
+
+    expect(result.map(s => s.reason)).toEqual(['0', '1', '2'])
+  })
+
+  it('should merge options with defaults', () => {
+    const windowCapture = createStrategy(
+      () => (ctx) => {
+        return { action: 'hold', reason: String(ctx.bars.length) }
+      },
+      { windowSize: 5 },
+    )
+
+    // Override windowSize to 2
+    const bars = [bar(1), bar(2), bar(3)]
+    const result = collect(windowCapture(bars, { windowSize: 2 }))
+
+    expect(result.map(s => s.reason)).toEqual(['1', '2', '2'])
+  })
+
+  it('should not mutate defaultOptions', () => {
+    const opts = dummyStrategy.defaultOptions
+    opts.windowSize = 999
+
+    expect(dummyStrategy.defaultOptions).toEqual({ windowSize: 3 })
+  })
+
+  it('should pass the current bar directly in context', () => {
+    const barCheck = createStrategy(
+      () => (ctx) => {
+        return { action: 'hold', reason: String(ctx.bar.c) }
+      },
+      { windowSize: 2 },
+    )
+
+    const bars = [bar(42), bar(99)]
+    const result = collect(barCheck(bars))
+
+    expect(result[0].reason).toBe('42')
+    expect(result[1].reason).toBe('99')
+  })
+
+  it('should return empty array when source is empty', () => {
+    expect(collect(dummyStrategy([]))).toEqual([])
+  })
+
+  it('should work with for...of iteration', () => {
+    const bars = [bar(1), bar(2)]
+    const result: StrategySignal[] = []
+
+    for (const signal of dummyStrategy(bars)) {
+      result.push(signal)
+    }
+
+    expect(result).toHaveLength(2)
+  })
+})

--- a/packages/strategies/tests/builtin/goldenCross.spec.ts
+++ b/packages/strategies/tests/builtin/goldenCross.spec.ts
@@ -1,0 +1,114 @@
+import { collect } from '@material-tech/alloy-core'
+import { goldenCross } from '@material-tech/alloy-strategies'
+import { describe, expect, it } from 'vitest'
+
+function bar(c: number) {
+  return { h: c, l: c, o: c, c, v: 100 }
+}
+
+describe('goldenCross', () => {
+  it('should have correct default options', () => {
+    expect(goldenCross.defaultOptions).toEqual({
+      windowSize: 2,
+      fastPeriod: 50,
+      slowPeriod: 200,
+      stopLossPercent: 0.02,
+    })
+  })
+
+  it('should emit hold when no crossover occurs', () => {
+    // With period 2, both SMAs see the same data — no cross
+    const bars = [bar(10), bar(10), bar(10)]
+    const result = collect(goldenCross(bars, {
+      fastPeriod: 2,
+      slowPeriod: 2,
+      windowSize: 2,
+    }))
+
+    expect(result.every(s => s.action === 'hold')).toBe(true)
+  })
+
+  it('should detect golden cross (fast crosses above slow)', () => {
+    // Construct a scenario where fast SMA (period 2) crosses above slow SMA (period 4)
+    // Start with declining prices so slow > fast, then prices jump up
+    const bars = [
+      bar(10),
+      bar(9),
+      bar(8),
+      bar(7), // declining: slow SMA lags, fast follows
+      bar(20),
+      bar(25), // sharp rise: fast SMA jumps above slow
+    ]
+
+    const result = collect(goldenCross(bars, {
+      fastPeriod: 2,
+      slowPeriod: 4,
+      windowSize: 2,
+      stopLossPercent: 0.05,
+    }))
+
+    const longSignals = result.filter(s => s.action === 'long')
+    expect(longSignals.length).toBeGreaterThanOrEqual(1)
+    expect(longSignals[0].reason).toContain('Golden cross')
+    expect(longSignals[0].stopLoss).toBeDefined()
+  })
+
+  it('should detect death cross (fast crosses below slow)', () => {
+    // Start with rising prices, then sharp drop
+    const bars = [
+      bar(20),
+      bar(22),
+      bar(24),
+      bar(26), // rising
+      bar(10),
+      bar(5), // sharp drop
+    ]
+
+    const result = collect(goldenCross(bars, {
+      fastPeriod: 2,
+      slowPeriod: 4,
+      windowSize: 2,
+      stopLossPercent: 0.03,
+    }))
+
+    const shortSignals = result.filter(s => s.action === 'short')
+    expect(shortSignals.length).toBeGreaterThanOrEqual(1)
+    expect(shortSignals[0].reason).toContain('Death cross')
+    expect(shortSignals[0].stopLoss).toBeDefined()
+  })
+
+  it('should set correct stop-loss based on percentage', () => {
+    const bars = [
+      bar(10),
+      bar(9),
+      bar(8),
+      bar(7),
+      bar(20),
+      bar(25),
+    ]
+
+    const result = collect(goldenCross(bars, {
+      fastPeriod: 2,
+      slowPeriod: 4,
+      windowSize: 2,
+      stopLossPercent: 0.05,
+    }))
+
+    const longSignal = result.find(s => s.action === 'long')
+    if (longSignal && longSignal.stopLoss !== undefined) {
+      // Stop loss should be entry price * (1 - 0.05)
+      const entryPrice = Number(bars[result.indexOf(longSignal)].c)
+      expect(longSignal.stopLoss).toBeCloseTo(entryPrice * 0.95, 2)
+    }
+  })
+
+  it('should create independent processors via .create()', () => {
+    const p1 = goldenCross.create({ fastPeriod: 2, slowPeriod: 3, windowSize: 2 })
+    const p2 = goldenCross.create({ fastPeriod: 2, slowPeriod: 3, windowSize: 2 })
+
+    const s1 = p1(bar(10))
+    const s2 = p2(bar(10))
+
+    expect(s1.action).toBe(s2.action)
+  })
+})

--- a/packages/strategies/tests/builtin/rsiOversoldOverbought.spec.ts
+++ b/packages/strategies/tests/builtin/rsiOversoldOverbought.spec.ts
@@ -1,0 +1,126 @@
+import { collect } from '@material-tech/alloy-core'
+import { rsiOversoldOverbought } from '@material-tech/alloy-strategies'
+import { describe, expect, it } from 'vitest'
+
+function bar(c: number) {
+  return { h: c, l: c, o: c, c, v: 100 }
+}
+
+describe('rsiOversoldOverbought', () => {
+  it('should have correct default options', () => {
+    expect(rsiOversoldOverbought.defaultOptions).toEqual({
+      windowSize: 2,
+      period: 14,
+      overboughtLevel: 70,
+      oversoldLevel: 30,
+    })
+  })
+
+  it('should emit hold when RSI stays in neutral zone', () => {
+    // Flat prices after warmup — RSI stays at 100 (no loss) and never crosses thresholds
+    // First we warm up with rising prices to get RSI stable, then flat prices
+    const warmup = Array.from({ length: 10 }, (_, i) => bar(100 + i))
+    const flat = Array.from({ length: 10 }, () => bar(110))
+    const bars = [...warmup, ...flat]
+
+    const result = collect(rsiOversoldOverbought(bars, {
+      period: 5,
+      overboughtLevel: 90,
+      oversoldLevel: 10,
+      windowSize: 2,
+    }))
+
+    // After warmup, RSI stays at 100 (all gains, no losses) — no crossover signals
+    // Check that flat-price portion produces only hold
+    const flatResults = result.slice(warmup.length)
+    expect(flatResults.every(s => s.action === 'hold')).toBe(true)
+  })
+
+  it('should detect oversold reversal (long signal)', () => {
+    // Create a scenario: prices drop sharply (RSI < 30), then recover (RSI > 30)
+    const bars = [
+      bar(100),
+      bar(90),
+      bar(80),
+      bar(70),
+      bar(60),
+      bar(50), // sharp drop → RSI very low
+      bar(55),
+      bar(60),
+      bar(65),
+      bar(70), // recovery → RSI crosses back above 30
+    ]
+
+    const result = collect(rsiOversoldOverbought(bars, {
+      period: 3,
+      oversoldLevel: 30,
+      overboughtLevel: 70,
+      windowSize: 2,
+    }))
+
+    const longSignals = result.filter(s => s.action === 'long')
+    expect(longSignals.length).toBeGreaterThanOrEqual(1)
+    expect(longSignals[0].reason).toContain('oversold')
+  })
+
+  it('should detect overbought reversal (short signal)', () => {
+    // Prices rise sharply (RSI > 70), then pull back (RSI < 70)
+    const bars = [
+      bar(50),
+      bar(60),
+      bar(70),
+      bar(80),
+      bar(90),
+      bar(100), // sharp rise → RSI very high
+      bar(95),
+      bar(90),
+      bar(85),
+      bar(80), // pullback → RSI crosses below 70
+    ]
+
+    const result = collect(rsiOversoldOverbought(bars, {
+      period: 3,
+      oversoldLevel: 30,
+      overboughtLevel: 70,
+      windowSize: 2,
+    }))
+
+    const shortSignals = result.filter(s => s.action === 'short')
+    expect(shortSignals.length).toBeGreaterThanOrEqual(1)
+    expect(shortSignals[0].reason).toContain('overbought')
+  })
+
+  it('should create independent processors via .create()', () => {
+    const p1 = rsiOversoldOverbought.create({ period: 5, windowSize: 2 })
+    const p2 = rsiOversoldOverbought.create({ period: 5, windowSize: 2 })
+
+    const signal1 = p1(bar(100))
+    const signal2 = p2(bar(100))
+
+    expect(signal1.action).toBe(signal2.action)
+  })
+
+  it('should accept custom overbought/oversold levels', () => {
+    // Very tight levels: overbought=60, oversold=40
+    const bars = [
+      bar(100),
+      bar(90),
+      bar(80),
+      bar(75), // drop
+      bar(80),
+      bar(85),
+      bar(90), // recovery
+    ]
+
+    const result = collect(rsiOversoldOverbought(bars, {
+      period: 3,
+      oversoldLevel: 40,
+      overboughtLevel: 60,
+      windowSize: 2,
+    }))
+
+    // With tight levels, we should see signals more easily
+    const actions = result.map(s => s.action)
+    expect(actions).toContain('long')
+  })
+})

--- a/packages/strategies/tsconfig.json
+++ b/packages/strategies/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@material-tech/alloy-core": ["../core/src/index.ts"],
+      "@material-tech/alloy-indicators": ["../indicators/src/index.ts"],
+      "@material-tech/alloy-strategies": ["./src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "tests/**/*.spec.ts"]
+}

--- a/packages/strategies/tsdown.config.ts
+++ b/packages/strategies/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  target: 'es2020',
+  clean: true,
+  dts: true,
+  exports: true,
+  sourcemap: true,
+  platform: 'neutral',
+})

--- a/packages/strategies/vitest.config.ts
+++ b/packages/strategies/vitest.config.ts
@@ -1,0 +1,15 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ['tests/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/index.ts'],
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@material-tech/alloy-indicators':
         specifier: workspace:^
         version: link:../indicators
+      '@material-tech/alloy-strategies':
+        specifier: workspace:^
+        version: link:../strategies
     devDependencies:
       '@types/node':
         specifier: catalog:build
@@ -138,6 +141,28 @@ importers:
       defu:
         specifier: catalog:runtime
         version: 6.1.4
+      vite-tsconfig-paths:
+        specifier: catalog:test
+        version: 6.1.1(typescript@5.9.3)(vite@6.3.3(@types/node@25.2.3)(jiti@2.5.1)(yaml@2.8.2))
+      vitest:
+        specifier: catalog:test
+        version: 4.0.18(@types/node@25.2.3)(jiti@2.5.1)(yaml@2.8.2)
+
+  packages/strategies:
+    dependencies:
+      '@material-tech/alloy-core':
+        specifier: workspace:^
+        version: link:../core
+      '@material-tech/alloy-indicators':
+        specifier: workspace:^
+        version: link:../indicators
+      defu:
+        specifier: catalog:runtime
+        version: 6.1.4
+      dnum:
+        specifier: catalog:runtime
+        version: 2.17.0
+    devDependencies:
       vite-tsconfig-paths:
         specifier: catalog:test
         version: 6.1.1(typescript@5.9.3)(vite@6.3.3(@types/node@25.2.3)(jiti@2.5.1)(yaml@2.8.2))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@material-tech/alloy-core": ["./packages/core/src/index.ts"],
       "@material-tech/alloy-indicators": ["./packages/indicators/src/index.ts"],
+      "@material-tech/alloy-strategies": ["./packages/strategies/src/index.ts"],
       "@material-tech/alloy-adapters": ["./packages/adapters/src/index.ts"],
       "@material-tech/alloy-adapters/*": ["./packages/adapters/src/*.ts"],
       "@material-tech/alloy": ["./packages/alloy/src/index.ts"],


### PR DESCRIPTION
## Summary

- Add new `@material-tech/alloy-strategies` package with `createStrategy` factory function that mirrors `createSignal` from core, adding rolling window management (`createRingBuffer`) and structured signal output (`StrategySignal`)
- Include two built-in strategies: **Golden Cross** (dual SMA crossover with stop-loss) and **RSI Oversold/Overbought** (RSI level crossover reversal)
- Integrate into `@material-tech/alloy` umbrella package so all strategies are available via unified entry point

## Test plan

- [x] `createStrategy` core tests: generator pattern, `.create()` independence, window size, bars ordering, options merging, defaultOptions immutability (11 tests)
- [x] Golden Cross strategy tests: crossover detection, stop-loss calculation, independent processors (6 tests)
- [x] RSI Oversold/Overbought strategy tests: oversold/overbought reversal signals, custom levels (6 tests)
- [x] Full monorepo validation: `pnpm build && pnpm test --run` — 29 test files, 99 tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)