### PR TITLE
fix: add missing decimal precision parameter to RSI div() call

### DIFF
--- a/packages/indicators/src/momentum/relativeStrengthIndex.ts
+++ b/packages/indicators/src/momentum/relativeStrengthIndex.ts
@@ -49,7 +49,7 @@ export const rsi = createSignal(
         return from(100, 18)
       }
 
-      const rs = div(avgGain, avgLoss)
+      const rs = div(avgGain, avgLoss, 18)
       return sub(100, div(100, add(1, rs), 18))
     }
   },


### PR DESCRIPTION
## Summary

- The RS calculation `div(avgGain, avgLoss)` in RSI was missing the third decimal parameter `18`, which could cause integer truncation and produce incorrect RSI values.
- All other `div()` / `divide()` calls in the codebase already pass `18` as required by the project's dnum precision rules.

## Test plan

- [x] All 52 existing indicator tests pass
- [ ] Verify RSI output values remain consistent with expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)