### PR TITLE
fix: add division by zero guard in A/D indicator

### DIFF
--- a/packages/indicators/src/volume/accumulationDistribution.ts
+++ b/packages/indicators/src/volume/accumulationDistribution.ts
@@ -1,7 +1,7 @@
 import type { CandleData, RequiredProperties } from '@material-tech/vulcan-core'
 import type { Dnum } from 'dnum'
 import { createSignal } from '@material-tech/vulcan-core'
-import { add, divide, from, multiply, subtract } from 'dnum'
+import { add, divide, equal, from, multiply, subtract } from 'dnum'
 
 /**
  * Accumulation/Distribution Indicator (A/D). Cumulative indicator
@@ -21,11 +21,15 @@ export const ad = createSignal(
       const c = from(bar.c, 18)
       const v = from(bar.v, 18)
 
-      const mfm = divide(
-        subtract(subtract(c, l), subtract(h, c)),
-        subtract(h, l),
-        18,
-      )
+      const range = subtract(h, l)
+      // When high equals low, the range is zero and MFM is undefined; treat as 0
+      const mfm = equal(range, 0)
+        ? from(0, 18)
+        : divide(
+            subtract(subtract(c, l), subtract(h, c)),
+            range,
+            18,
+          )
       const mfv = multiply(mfm, v)
       prevAD = add(mfv, prevAD)
       return prevAD

--- a/packages/indicators/tests/volume/accumulationDistribution.spec.ts
+++ b/packages/indicators/tests/volume/accumulationDistribution.spec.ts
@@ -17,4 +17,14 @@ describe('accumulation distribution (A/D)', () => {
     const result = collect(ad(values))
     expect(result).toMatchNumberArray(expected)
   })
+
+  it('should handle zero range (high === low) without division by zero', () => {
+    const values = [
+      { h: 10, l: 10, c: 10, v: 100 },
+      { h: 10, l: 6, c: 9, v: 200 },
+    ]
+
+    const result = collect(ad(values))
+    expect(result).toMatchNumberArray([0, 100])
+  })
 })


### PR DESCRIPTION
## Summary

- When high and low prices are equal (zero range), the A/D indicator's MFM calculation divides by zero, causing a runtime error.
- Added an `equal(range, 0)` guard that returns MFM as `0` in this edge case.
- Added test case covering the `h === l` scenario.

## Test plan

- [x] All 53 indicator tests pass (including new zero-range test)
- [ ] Verify A/D output remains correct for normal candle data

🤖 Generated with [Claude Code](https://claude.com/claude-code)