### PR TITLE
fix: use deep copy for defaultOptions to prevent nested mutation

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -25,7 +25,7 @@ export function createSignal<Input, Output, Options extends Record<string, any>>
 
   Object.defineProperty(generator, 'defaultOptions', {
     get() {
-      return defu(defaultOptions)
+      return defaultOptions ? JSON.parse(JSON.stringify(defaultOptions)) : {}
     },
   })
 

--- a/packages/strategies/src/base.ts
+++ b/packages/strategies/src/base.ts
@@ -71,7 +71,7 @@ export function createStrategy<Opts extends BaseStrategyOptions>(
 
   Object.defineProperty(generator, 'defaultOptions', {
     get() {
-      return defu(defaultOptions)
+      return JSON.parse(JSON.stringify(defaultOptions))
     },
   })
 


### PR DESCRIPTION
## Summary

- `defu()` only performs a shallow copy, so nested objects in `defaultOptions` could be mutated by external callers, polluting all future reads.
- Replaced with `JSON.parse(JSON.stringify())` in both `core` and `strategies` packages to ensure full isolation.
- Handles the `undefined` case (no defaultOptions provided) by returning `{}`.

## Test plan

- [x] All 138 tests pass across all packages
- [ ] Verify `defaultOptions` returns independent deep copies on each access

🤖 Generated with [Claude Code](https://claude.com/claude-code)