### PR TITLE
refactor(backtest): migrate to dnum precision

### DIFF
--- a/packages/backtest/src/convert.ts
+++ b/packages/backtest/src/convert.ts
@@ -1,20 +1,18 @@
 import type { Numberish } from 'dnum'
 import type { CandleData, NormalizedBar } from './types'
-import { from, toNumber } from 'dnum'
+import { from } from 'dnum'
 
-function toNum(value: Numberish): number {
-  if (typeof value === 'number')
-    return value
-  return toNumber(from(value))
+function toDnum(value: Numberish) {
+  return from(value, 18)
 }
 
 export function normalizeBar(bar: CandleData): NormalizedBar {
   return {
-    o: toNum(bar.o),
-    h: toNum(bar.h),
-    l: toNum(bar.l),
-    c: toNum(bar.c),
-    v: toNum(bar.v),
+    o: toDnum(bar.o),
+    h: toDnum(bar.h),
+    l: toDnum(bar.l),
+    c: toDnum(bar.c),
+    v: toDnum(bar.v),
     ...(bar.timestamp !== undefined && { timestamp: bar.timestamp }),
   }
 }

--- a/packages/backtest/src/types.ts
+++ b/packages/backtest/src/types.ts
@@ -1,20 +1,21 @@
 import type { CandleData } from '@material-tech/vulcan-core'
 import type { StrategySignal } from '@material-tech/vulcan-strategies'
+import type { Dnum, Numberish } from 'dnum'
 
 export type { CandleData, StrategySignal }
 
 export interface NormalizedBar {
-  o: number
-  h: number
-  l: number
-  c: number
-  v: number
+  o: Dnum
+  h: Dnum
+  l: Dnum
+  c: Dnum
+  v: Dnum
   timestamp?: number | Date | string
 }
 
 export interface BacktestOptions {
   /** Initial capital, defaults to 10000 */
-  initialCapital: number
+  initialCapital: Numberish
   /** Commission rate (0–1), defaults to 0 */
   commissionRate: number
   /** Slippage rate (0–1), defaults to 0 */
@@ -27,22 +28,22 @@ export type PositionSide = 'long' | 'short'
 
 export interface Position {
   side: PositionSide
-  entryPrice: number
-  quantity: number
+  entryPrice: Dnum
+  quantity: Dnum
   size: number
   entryIndex: number
-  stopLoss?: number
-  takeProfit?: number
+  stopLoss?: Dnum
+  takeProfit?: Dnum
 }
 
 export interface Trade {
   side: PositionSide
-  entryPrice: number
-  exitPrice: number
+  entryPrice: Dnum
+  exitPrice: Dnum
   size: number
-  quantity: number
-  pnl: number
-  returnRate: number
+  quantity: Dnum
+  pnl: Dnum
+  returnRate: Dnum
   entryIndex: number
   exitIndex: number
   exitReason: 'signal' | 'stop_loss' | 'take_profit' | 'end_of_data'
@@ -53,17 +54,17 @@ export interface BacktestSnapshot {
   bar: NormalizedBar
   signal: StrategySignal
   position: Position | null
-  equity: number
-  unrealizedPnl: number
-  totalEquity: number
+  equity: Dnum
+  unrealizedPnl: Dnum
+  totalEquity: Dnum
   closedTrade: Trade | null
 }
 
 export interface BacktestResult {
   trades: Trade[]
   statistics: BacktestStatistics
-  equityCurve: number[]
-  finalEquity: number
+  equityCurve: Dnum[]
+  finalEquity: Dnum
 }
 
 export interface BacktestStatistics {

--- a/packages/backtest/tests/position.spec.ts
+++ b/packages/backtest/tests/position.spec.ts
@@ -1,5 +1,6 @@
 import type { BacktestOptions, NormalizedBar, Position } from '@material-tech/vulcan-backtest'
 import type { StrategySignal } from '@material-tech/vulcan-strategies'
+import { from, toNumber } from 'dnum'
 import { describe, expect, it } from 'vitest'
 import { applySlippage, closePositionAtEnd, updatePosition } from '../src/position'
 
@@ -10,8 +11,12 @@ const defaultOptions: BacktestOptions = {
   allowShort: true,
 }
 
+function d(value: number) {
+  return from(value, 18)
+}
+
 function bar(overrides: Partial<NormalizedBar> = {}): NormalizedBar {
-  return { o: 100, h: 105, l: 95, c: 102, v: 1000, ...overrides }
+  return { o: d(100), h: d(105), l: d(95), c: d(102), v: d(1000), ...overrides }
 }
 
 function holdSignal(): StrategySignal {
@@ -32,33 +37,33 @@ function closeSignal(): StrategySignal {
 
 describe('applySlippage', () => {
   it('increases price for buy direction', () => {
-    expect(applySlippage(100, 'buy', 0.01)).toBe(101)
+    expect(toNumber(applySlippage(d(100), 'buy', 0.01))).toBeCloseTo(101)
   })
 
   it('decreases price for sell direction', () => {
-    expect(applySlippage(100, 'sell', 0.01)).toBe(99)
+    expect(toNumber(applySlippage(d(100), 'sell', 0.01))).toBeCloseTo(99)
   })
 
   it('returns exact price when slippage is 0', () => {
-    expect(applySlippage(100, 'buy', 0)).toBe(100)
-    expect(applySlippage(100, 'sell', 0)).toBe(100)
+    expect(toNumber(applySlippage(d(100), 'buy', 0))).toBe(100)
+    expect(toNumber(applySlippage(d(100), 'sell', 0))).toBe(100)
   })
 })
 
 describe('updatePosition — FLAT state', () => {
   it('opens long on long signal', () => {
-    const result = updatePosition(null, longSignal(), bar(), 0, 10000, defaultOptions)
+    const result = updatePosition(null, longSignal(), bar(), 0, d(10000), defaultOptions)
 
     expect(result.closedTrade).toBeNull()
     expect(result.position).not.toBeNull()
     expect(result.position!.side).toBe('long')
-    expect(result.position!.entryPrice).toBe(102)
-    expect(result.position!.quantity).toBeCloseTo(10000 / 102)
+    expect(toNumber(result.position!.entryPrice)).toBe(102)
+    expect(toNumber(result.position!.quantity)).toBeCloseTo(10000 / 102)
     expect(result.position!.entryIndex).toBe(0)
   })
 
   it('opens short on short signal when allowed', () => {
-    const result = updatePosition(null, shortSignal(), bar(), 0, 10000, defaultOptions)
+    const result = updatePosition(null, shortSignal(), bar(), 0, d(10000), defaultOptions)
 
     expect(result.closedTrade).toBeNull()
     expect(result.position).not.toBeNull()
@@ -67,69 +72,69 @@ describe('updatePosition — FLAT state', () => {
 
   it('ignores short signal when allowShort is false', () => {
     const opts = { ...defaultOptions, allowShort: false }
-    const result = updatePosition(null, shortSignal(), bar(), 0, 10000, opts)
+    const result = updatePosition(null, shortSignal(), bar(), 0, d(10000), opts)
 
     expect(result.position).toBeNull()
     expect(result.closedTrade).toBeNull()
   })
 
   it('does nothing on hold signal', () => {
-    const result = updatePosition(null, holdSignal(), bar(), 0, 10000, defaultOptions)
+    const result = updatePosition(null, holdSignal(), bar(), 0, d(10000), defaultOptions)
     expect(result.position).toBeNull()
     expect(result.closedTrade).toBeNull()
   })
 
   it('does nothing on close signal', () => {
-    const result = updatePosition(null, closeSignal(), bar(), 0, 10000, defaultOptions)
+    const result = updatePosition(null, closeSignal(), bar(), 0, d(10000), defaultOptions)
     expect(result.position).toBeNull()
     expect(result.closedTrade).toBeNull()
   })
 
   it('respects size from signal', () => {
-    const result = updatePosition(null, longSignal({ size: 0.5 }), bar(), 0, 10000, defaultOptions)
+    const result = updatePosition(null, longSignal({ size: 0.5 }), bar(), 0, d(10000), defaultOptions)
 
     expect(result.position!.size).toBe(0.5)
-    expect(result.position!.quantity).toBeCloseTo(5000 / 102)
+    expect(toNumber(result.position!.quantity)).toBeCloseTo(5000 / 102)
   })
 })
 
 describe('updatePosition — LONG state', () => {
   const longPos: Position = {
     side: 'long',
-    entryPrice: 100,
-    quantity: 100,
+    entryPrice: d(100),
+    quantity: d(100),
     size: 1,
     entryIndex: 0,
   }
 
   it('holds on hold signal', () => {
-    const result = updatePosition(longPos, holdSignal(), bar(), 1, 10000, defaultOptions)
+    const result = updatePosition(longPos, holdSignal(), bar(), 1, d(10000), defaultOptions)
     expect(result.position).toBe(longPos)
     expect(result.closedTrade).toBeNull()
   })
 
   it('holds on long signal', () => {
-    const result = updatePosition(longPos, longSignal(), bar(), 1, 10000, defaultOptions)
+    const result = updatePosition(longPos, longSignal(), bar(), 1, d(10000), defaultOptions)
     expect(result.position).toBe(longPos)
     expect(result.closedTrade).toBeNull()
   })
 
   it('closes on close signal', () => {
-    const result = updatePosition(longPos, closeSignal(), bar({ c: 110 }), 1, 10000, defaultOptions)
+    const result = updatePosition(longPos, closeSignal(), bar({ c: d(110) }), 1, d(10000), defaultOptions)
 
     expect(result.position).toBeNull()
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.side).toBe('long')
-    expect(result.closedTrade!.pnl).toBeCloseTo((110 - 100) * 100) // +1000
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((110 - 100) * 100) // +1000
     expect(result.closedTrade!.exitReason).toBe('signal')
   })
 
   it('reverses to short on short signal', () => {
-    const result = updatePosition(longPos, shortSignal(), bar({ c: 110 }), 1, 10000, defaultOptions)
+    const result = updatePosition(longPos, shortSignal(), bar({ c: d(110) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.side).toBe('long')
-    expect(result.closedTrade!.pnl).toBeCloseTo(1000)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo(1000)
 
     expect(result.position).not.toBeNull()
     expect(result.position!.side).toBe('short')
@@ -137,7 +142,7 @@ describe('updatePosition — LONG state', () => {
 
   it('just closes long on short signal when allowShort is false', () => {
     const opts = { ...defaultOptions, allowShort: false }
-    const result = updatePosition(longPos, shortSignal(), bar({ c: 110 }), 1, 10000, opts)
+    const result = updatePosition(longPos, shortSignal(), bar({ c: d(110) }), 1, d(10000), opts)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.position).toBeNull()
@@ -147,40 +152,40 @@ describe('updatePosition — LONG state', () => {
 describe('updatePosition — SHORT state', () => {
   const shortPos: Position = {
     side: 'short',
-    entryPrice: 100,
-    quantity: 100,
+    entryPrice: d(100),
+    quantity: d(100),
     size: 1,
     entryIndex: 0,
   }
 
   it('holds on hold signal', () => {
-    const result = updatePosition(shortPos, holdSignal(), bar(), 1, 10000, defaultOptions)
+    const result = updatePosition(shortPos, holdSignal(), bar(), 1, d(10000), defaultOptions)
     expect(result.position).toBe(shortPos)
     expect(result.closedTrade).toBeNull()
   })
 
   it('holds on short signal', () => {
-    const result = updatePosition(shortPos, shortSignal(), bar(), 1, 10000, defaultOptions)
+    const result = updatePosition(shortPos, shortSignal(), bar(), 1, d(10000), defaultOptions)
     expect(result.position).toBe(shortPos)
     expect(result.closedTrade).toBeNull()
   })
 
   it('closes on close signal', () => {
-    const result = updatePosition(shortPos, closeSignal(), bar({ c: 90 }), 1, 10000, defaultOptions)
+    const result = updatePosition(shortPos, closeSignal(), bar({ c: d(90) }), 1, d(10000), defaultOptions)
 
     expect(result.position).toBeNull()
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.side).toBe('short')
-    expect(result.closedTrade!.pnl).toBeCloseTo((100 - 90) * 100) // +1000
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((100 - 90) * 100) // +1000
     expect(result.closedTrade!.exitReason).toBe('signal')
   })
 
   it('reverses to long on long signal', () => {
-    const result = updatePosition(shortPos, longSignal(), bar({ c: 90 }), 1, 10000, defaultOptions)
+    const result = updatePosition(shortPos, longSignal(), bar({ c: d(90) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.side).toBe('short')
-    expect(result.closedTrade!.pnl).toBeCloseTo(1000)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo(1000)
 
     expect(result.position).not.toBeNull()
     expect(result.position!.side).toBe('long')
@@ -191,52 +196,52 @@ describe('updatePosition — stop loss', () => {
   it('triggers stop loss for long position', () => {
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      stopLoss: 96,
+      stopLoss: d(96),
     }
     // bar.l = 95 triggers SL at 96
-    const result = updatePosition(pos, longSignal(), bar({ l: 95 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, longSignal(), bar({ l: d(95) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.exitReason).toBe('stop_loss')
-    expect(result.closedTrade!.exitPrice).toBe(96)
-    expect(result.closedTrade!.pnl).toBeCloseTo((96 - 100) * 100) // -400
+    expect(toNumber(result.closedTrade!.exitPrice)).toBe(96)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((96 - 100) * 100) // -400
     expect(result.position).toBeNull()
   })
 
   it('triggers stop loss for short position', () => {
     const pos: Position = {
       side: 'short',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      stopLoss: 104,
+      stopLoss: d(104),
     }
     // bar.h = 105 triggers SL at 104
-    const result = updatePosition(pos, shortSignal(), bar({ h: 105 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, shortSignal(), bar({ h: d(105) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.exitReason).toBe('stop_loss')
-    expect(result.closedTrade!.exitPrice).toBe(104)
-    expect(result.closedTrade!.pnl).toBeCloseTo((100 - 104) * 100) // -400
+    expect(toNumber(result.closedTrade!.exitPrice)).toBe(104)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((100 - 104) * 100) // -400
     expect(result.position).toBeNull()
   })
 
   it('ignores signal when SL triggers', () => {
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      stopLoss: 96,
+      stopLoss: d(96),
     }
     // SL triggers, short signal is ignored (no new position opened)
-    const result = updatePosition(pos, shortSignal(), bar({ l: 95 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, shortSignal(), bar({ l: d(95) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade!.exitReason).toBe('stop_loss')
     expect(result.position).toBeNull()
@@ -247,51 +252,51 @@ describe('updatePosition — take profit', () => {
   it('triggers take profit for long position', () => {
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      takeProfit: 110,
+      takeProfit: d(110),
     }
-    const result = updatePosition(pos, holdSignal(), bar({ h: 112 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, holdSignal(), bar({ h: d(112) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.exitReason).toBe('take_profit')
-    expect(result.closedTrade!.exitPrice).toBe(110)
-    expect(result.closedTrade!.pnl).toBeCloseTo((110 - 100) * 100) // +1000
+    expect(toNumber(result.closedTrade!.exitPrice)).toBe(110)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((110 - 100) * 100) // +1000
     expect(result.position).toBeNull()
   })
 
   it('triggers take profit for short position', () => {
     const pos: Position = {
       side: 'short',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      takeProfit: 90,
+      takeProfit: d(90),
     }
-    const result = updatePosition(pos, holdSignal(), bar({ l: 88 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, holdSignal(), bar({ l: d(88) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade).not.toBeNull()
     expect(result.closedTrade!.exitReason).toBe('take_profit')
-    expect(result.closedTrade!.exitPrice).toBe(90)
-    expect(result.closedTrade!.pnl).toBeCloseTo((100 - 90) * 100)
+    expect(toNumber(result.closedTrade!.exitPrice)).toBe(90)
+    expect(toNumber(result.closedTrade!.pnl)).toBeCloseTo((100 - 90) * 100)
     expect(result.position).toBeNull()
   })
 
   it('checks SL before TP', () => {
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
-      stopLoss: 96,
-      takeProfit: 110,
+      stopLoss: d(96),
+      takeProfit: d(110),
     }
     // Both SL and TP would trigger in same bar — SL takes priority
-    const result = updatePosition(pos, holdSignal(), bar({ l: 95, h: 112 }), 1, 10000, defaultOptions)
+    const result = updatePosition(pos, holdSignal(), bar({ l: d(95), h: d(112) }), 1, d(10000), defaultOptions)
 
     expect(result.closedTrade!.exitReason).toBe('stop_loss')
   })
@@ -302,31 +307,31 @@ describe('updatePosition — commission and slippage', () => {
     const opts: BacktestOptions = { ...defaultOptions, commissionRate: 0.001 }
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
     }
-    const result = updatePosition(pos, closeSignal(), bar({ c: 110 }), 1, 10000, opts)
+    const result = updatePosition(pos, closeSignal(), bar({ c: d(110) }), 1, d(10000), opts)
     const trade = result.closedTrade!
 
     // gross pnl = (110 - 100) * 100 = 1000
     // entry commission = 100 * 100 * 0.001 = 10
     // exit commission = 110 * 100 * 0.001 = 11
     // net pnl = 1000 - 10 - 11 = 979
-    expect(trade.pnl).toBeCloseTo(979)
+    expect(toNumber(trade.pnl)).toBeCloseTo(979)
   })
 
   it('applies slippage to entry and exit prices', () => {
     const opts: BacktestOptions = { ...defaultOptions, slippageRate: 0.01 }
 
     // Open long: entry price should be higher (buy slippage)
-    const openResult = updatePosition(null, longSignal(), bar({ c: 100 }), 0, 10000, opts)
-    expect(openResult.position!.entryPrice).toBeCloseTo(101) // 100 * 1.01
+    const openResult = updatePosition(null, longSignal(), bar({ c: d(100) }), 0, d(10000), opts)
+    expect(toNumber(openResult.position!.entryPrice)).toBeCloseTo(101) // 100 * 1.01
 
     // Close long: exit price should be lower (sell slippage)
-    const closeResult = updatePosition(openResult.position!, closeSignal(), bar({ c: 110 }), 1, 10000, opts)
-    expect(closeResult.closedTrade!.exitPrice).toBeCloseTo(108.9) // 110 * 0.99
+    const closeResult = updatePosition(openResult.position!, closeSignal(), bar({ c: d(110) }), 1, d(10000), opts)
+    expect(toNumber(closeResult.closedTrade!.exitPrice)).toBeCloseTo(108.9) // 110 * 0.99
   })
 })
 
@@ -334,16 +339,16 @@ describe('closePositionAtEnd', () => {
   it('closes position with end_of_data reason', () => {
     const pos: Position = {
       side: 'long',
-      entryPrice: 100,
-      quantity: 100,
+      entryPrice: d(100),
+      quantity: d(100),
       size: 1,
       entryIndex: 0,
     }
-    const trade = closePositionAtEnd(pos, bar({ c: 105 }), 5, defaultOptions)
+    const trade = closePositionAtEnd(pos, bar({ c: d(105) }), 5, defaultOptions)
 
     expect(trade.exitReason).toBe('end_of_data')
-    expect(trade.exitPrice).toBe(105)
+    expect(toNumber(trade.exitPrice)).toBe(105)
     expect(trade.exitIndex).toBe(5)
-    expect(trade.pnl).toBeCloseTo(500)
+    expect(toNumber(trade.pnl)).toBeCloseTo(500)
   })
 })


### PR DESCRIPTION
## Summary

- Migrate all internal price/amount calculations in the backtest package from `number` to `dnum` (18-decimal precision), aligning with the indicators package
- Update public API types: `NormalizedBar`, `Position`, `Trade`, `BacktestSnapshot`, `BacktestResult` now use `Dnum` for price/amount fields; `BacktestStatistics` remains `number` (display layer)
- Update all tests to work with `Dnum` types, using `toNumber()` for assertions

## Test plan

- [x] `pnpm build` — all packages build successfully
- [x] `pnpm test --run` — all 138 tests pass across 29 test files
- [x] Type checking passes (vitest `--typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)