### PR TITLE
feat(data): add @vulcan-js/pyrite for synthetic market data generation

### DIFF
--- a/packages/pyrite/package.json
+++ b/packages/pyrite/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@vulcan-js/pyrite",
+  "type": "module",
+  "version": "0.2.0",
+  "description": "Synthetic market data generator with GBM and jump diffusion models",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-tech/vulcan",
+    "directory": "packages/pyrite"
+  },
+  "keywords": [
+    "synthetic-data",
+    "market-data",
+    "gbm",
+    "geometric-brownian-motion",
+    "ohlcv",
+    "backtesting",
+    "trading"
+  ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@vulcan-js/core": "workspace:^",
+    "dnum": "catalog:runtime"
+  },
+  "devDependencies": {
+    "vitest": "catalog:test"
+  }
+}

--- a/packages/pyrite/src/aggregate.ts
+++ b/packages/pyrite/src/aggregate.ts
@@ -1,0 +1,79 @@
+import type { CandleData } from '@vulcan-js/core'
+import type { TickData, TimeFrame } from './types'
+import { fp18 } from '@vulcan-js/core'
+import { TIMEFRAME_MS } from './types'
+
+export function aggregateToOHLCV(
+  ticks: TickData[],
+  timeFrame: TimeFrame,
+  startTime: number,
+): CandleData[] {
+  if (ticks.length === 0)
+    return []
+
+  const interval = TIMEFRAME_MS[timeFrame]
+  const candles: CandleData[] = []
+  let currentBucket = Math.floor((ticks[0]!.timestamp - startTime) / interval) * interval + startTime
+
+  let open = ticks[0]!.price
+  let high = ticks[0]!.price
+  let low = ticks[0]!.price
+  let close = ticks[0]!.price
+  let volume = 0
+
+  for (const tick of ticks) {
+    const bucket = Math.floor((tick.timestamp - startTime) / interval) * interval + startTime
+
+    if (bucket !== currentBucket) {
+      candles.push({
+        o: fp18.toDnum(fp18.toFp18(open)),
+        h: fp18.toDnum(fp18.toFp18(high)),
+        l: fp18.toDnum(fp18.toFp18(low)),
+        c: fp18.toDnum(fp18.toFp18(close)),
+        v: fp18.toDnum(fp18.toFp18(volume)),
+        timestamp: currentBucket,
+      })
+
+      currentBucket = bucket
+      open = tick.price
+      high = tick.price
+      low = tick.price
+      volume = 0
+    }
+
+    high = Math.max(high, tick.price)
+    low = Math.min(low, tick.price)
+    close = tick.price
+    volume += tick.volume
+  }
+
+  if (volume > 0) {
+    candles.push({
+      o: fp18.toDnum(fp18.toFp18(open)),
+      h: fp18.toDnum(fp18.toFp18(high)),
+      l: fp18.toDnum(fp18.toFp18(low)),
+      c: fp18.toDnum(fp18.toFp18(close)),
+      v: fp18.toDnum(fp18.toFp18(volume)),
+      timestamp: currentBucket,
+    })
+  }
+
+  return candles
+}
+
+export function generateTimestamps(
+  count: number,
+  timeFrame: TimeFrame,
+  startTime: number,
+): number[] {
+  const interval = TIMEFRAME_MS[timeFrame]
+  const timestamps: number[] = []
+
+  for (let i = 0; i < count; i++) {
+    const baseTime = startTime + i * interval
+    const jitter = Math.floor(Math.random() * (interval * 0.8))
+    timestamps.push(baseTime + jitter)
+  }
+
+  return timestamps
+}

--- a/packages/pyrite/src/gbm.ts
+++ b/packages/pyrite/src/gbm.ts
@@ -1,0 +1,92 @@
+import type { GBMParams, JumpParams, PriceBoundaries, SeededRandom, TickData } from './types'
+
+export class Mulberry32 implements SeededRandom {
+  private state: number
+
+  constructor(seed: number) {
+    this.state = seed >>> 0
+  }
+
+  next(): number {
+    let z = (this.state += 0x6D2B79F5)
+    z = Math.imul(z ^ (z >>> 15), z | 1)
+    z ^= z + Math.imul(z ^ (z >>> 7), z | 61)
+    return ((z ^ (z >>> 14)) >>> 0) / 4294967296
+  }
+
+  nextNormal(): number {
+    const u1 = this.next()
+    const u2 = this.next()
+    return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+  }
+}
+
+export interface GBMEngineOptions {
+  gbm: GBMParams
+  jump?: JumpParams
+  boundaries: PriceBoundaries
+  rng: SeededRandom
+}
+
+export function createGBMEngine(options: GBMEngineOptions) {
+  const { gbm, jump, boundaries, rng } = options
+  const dt = gbm.dt ?? 1 / (252 * 24 * 60)
+  const drift = gbm.mu - 0.5 * gbm.sigma * gbm.sigma
+
+  let currentPrice = gbm.initialPrice
+
+  function applyBoundaries(price: number): number {
+    return Math.max(boundaries.minPrice, Math.min(boundaries.maxPrice, price))
+  }
+
+  function nextPrice(): number {
+    const z = rng.nextNormal()
+    let price = currentPrice * Math.exp(drift * dt + gbm.sigma * Math.sqrt(dt) * z)
+
+    if (jump) {
+      const jumpProb = jump.jumpIntensity * dt
+      if (rng.next() < jumpProb) {
+        const jumpZ = rng.nextNormal()
+        const jumpSize = Math.exp(jump.jumpMean + jump.jumpVol * jumpZ)
+        price *= jumpSize
+      }
+    }
+
+    price = applyBoundaries(price)
+    currentPrice = price
+    return price
+  }
+
+  return {
+    nextPrice,
+    getCurrentPrice: () => currentPrice,
+    reset: (price?: number) => {
+      currentPrice = price ?? gbm.initialPrice
+    },
+  }
+}
+
+export function generateTicks(
+  options: GBMEngineOptions,
+  count: number,
+  timestamps: number[],
+  baseVolume: number,
+  volumeVolatility: number,
+): TickData[] {
+  const engine = createGBMEngine(options)
+  const ticks: TickData[] = []
+
+  for (let i = 0; i < count; i++) {
+    const price = engine.nextPrice()
+    const volNoise = 1 + (options.rng.nextNormal() * 0.3)
+    const volume = Math.max(1, baseVolume * volNoise * (1 + Math.random() * volumeVolatility))
+
+    ticks.push({
+      price,
+      volume: Math.round(volume),
+      timestamp: timestamps[i]!,
+    })
+  }
+
+  return ticks
+}

--- a/packages/pyrite/src/index.ts
+++ b/packages/pyrite/src/index.ts
@@ -1,0 +1,208 @@
+import type { CandleData } from '@vulcan-js/core'
+import type {
+  GBMParams,
+  GenerateOptions,
+  JumpParams,
+  MarketSector,
+  MarketSentiment,
+  PriceBoundaries,
+  PyriteConfig,
+  SectorConfig,
+} from './types'
+import { aggregateToOHLCV, generateTimestamps } from './aggregate'
+import { generateTicks, Mulberry32 } from './gbm'
+import { mockLLMGenerate, resolveParams } from './prompt'
+import {
+  SECTOR_CONFIGS,
+  SENTIMENT_MULTIPLIERS,
+  TIMEFRAME_MS,
+} from './types'
+
+export * from './aggregate'
+export * from './gbm'
+export * from './prompt'
+export * from './types'
+
+export interface GenerateResult {
+  candles: CandleData[]
+  meta: {
+    params: GBMParams & Partial<JumpParams>
+    startTime: number
+    endTime: number
+    tickCount: number
+    seed: number
+  }
+}
+
+export async function generate(
+  config: PyriteConfig,
+  options: GenerateOptions,
+): Promise<GenerateResult> {
+  const sector: MarketSector = config.sector ?? 'custom'
+  const sentiment: MarketSentiment = config.sentiment ?? 'neutral'
+  const sectorConfig: SectorConfig = SECTOR_CONFIGS[sector]
+  const sentimentMult = SENTIMENT_MULTIPLIERS[sentiment]
+
+  const seed = config.seed ?? Date.now()
+  const rng = new Mulberry32(seed)
+
+  let gbmParams: GBMParams
+
+  if (config.useLLM) {
+    const promptContext = {
+      sector,
+      sentiment,
+      initialPrice: options.initialPrice ?? config.gbm?.initialPrice,
+    }
+    const llmResponse = await mockLLMGenerate(promptContext)
+    gbmParams = resolveParams(promptContext, llmResponse, config.gbm)
+  }
+  else {
+    gbmParams = {
+      mu: config.gbm?.mu ?? sectorConfig.baseDrift * sentimentMult.drift,
+      sigma: config.gbm?.sigma ?? sectorConfig.baseVolatility * sentimentMult.vol,
+      initialPrice: options.initialPrice ?? config.gbm?.initialPrice ?? 100,
+      dt: config.gbm?.dt,
+    }
+  }
+
+  const jumpParams: JumpParams | undefined = config.jump
+    ? {
+        jumpIntensity: config.jump.jumpIntensity ?? sectorConfig.jumpParams?.jumpIntensity ?? 0,
+        jumpMean: config.jump.jumpMean ?? sectorConfig.jumpParams?.jumpMean ?? 0,
+        jumpVol: config.jump.jumpVol ?? sectorConfig.jumpParams?.jumpVol ?? 0,
+      }
+    : sectorConfig.jumpParams
+
+  const boundaries: PriceBoundaries = {
+    minPrice: config.boundaries?.minPrice ?? sectorConfig.boundaries.minPrice,
+    maxPrice: config.boundaries?.maxPrice ?? sectorConfig.boundaries.maxPrice,
+  }
+
+  const timeFrame = options.timeFrame ?? '1h'
+  const interval = TIMEFRAME_MS[timeFrame]
+
+  const endTime = options.startTime
+    ? (typeof options.startTime === 'number' ? options.startTime : options.startTime.getTime()) + options.count * interval
+    : Date.now()
+
+  const startTime = options.startTime
+    ? (typeof options.startTime === 'number' ? options.startTime : options.startTime.getTime())
+    : endTime - options.count * interval
+
+  const ticksPerCandle = 100
+  const totalTicks = options.count * ticksPerCandle
+
+  const timestamps = generateTimestamps(totalTicks, timeFrame, startTime)
+
+  const baseVolume = options.baseVolume ?? 1000
+  const volumeVolatility = options.volumeVolatility ?? 0.5
+
+  const engineOptions = {
+    gbm: gbmParams,
+    jump: jumpParams,
+    boundaries,
+    rng,
+  }
+
+  const ticks = generateTicks(
+    engineOptions,
+    totalTicks,
+    timestamps,
+    baseVolume,
+    volumeVolatility,
+  )
+
+  const candles = aggregateToOHLCV(ticks, timeFrame, startTime)
+
+  return {
+    candles,
+    meta: {
+      params: { ...gbmParams, ...jumpParams },
+      startTime,
+      endTime,
+      tickCount: totalTicks,
+      seed,
+    },
+  }
+}
+
+export function generateSync(
+  config: PyriteConfig,
+  options: GenerateOptions,
+): GenerateResult {
+  const sector: MarketSector = config.sector ?? 'custom'
+  const sentiment: MarketSentiment = config.sentiment ?? 'neutral'
+  const sectorConfig: SectorConfig = SECTOR_CONFIGS[sector]
+  const sentimentMult = SENTIMENT_MULTIPLIERS[sentiment]
+
+  const seed = config.seed ?? Date.now()
+  const rng = new Mulberry32(seed)
+
+  const gbmParams: GBMParams = {
+    mu: config.gbm?.mu ?? sectorConfig.baseDrift * sentimentMult.drift,
+    sigma: config.gbm?.sigma ?? sectorConfig.baseVolatility * sentimentMult.vol,
+    initialPrice: options.initialPrice ?? config.gbm?.initialPrice ?? 100,
+    dt: config.gbm?.dt,
+  }
+
+  const jumpParams: JumpParams | undefined = config.jump
+    ? {
+        jumpIntensity: config.jump.jumpIntensity ?? sectorConfig.jumpParams?.jumpIntensity ?? 0,
+        jumpMean: config.jump.jumpMean ?? sectorConfig.jumpParams?.jumpMean ?? 0,
+        jumpVol: config.jump.jumpVol ?? sectorConfig.jumpParams?.jumpVol ?? 0,
+      }
+    : sectorConfig.jumpParams
+
+  const boundaries: PriceBoundaries = {
+    minPrice: config.boundaries?.minPrice ?? sectorConfig.boundaries.minPrice,
+    maxPrice: config.boundaries?.maxPrice ?? sectorConfig.boundaries.maxPrice,
+  }
+
+  const timeFrame = options.timeFrame ?? '1h'
+  const interval = TIMEFRAME_MS[timeFrame]
+
+  const endTime = options.startTime
+    ? (typeof options.startTime === 'number' ? options.startTime : options.startTime.getTime()) + options.count * interval
+    : Date.now()
+
+  const startTime = options.startTime
+    ? (typeof options.startTime === 'number' ? options.startTime : options.startTime.getTime())
+    : endTime - options.count * interval
+
+  const ticksPerCandle = 100
+  const totalTicks = options.count * ticksPerCandle
+
+  const timestamps = generateTimestamps(totalTicks, timeFrame, startTime)
+
+  const baseVolume = options.baseVolume ?? 1000
+  const volumeVolatility = options.volumeVolatility ?? 0.5
+
+  const engineOptions = {
+    gbm: gbmParams,
+    jump: jumpParams,
+    boundaries,
+    rng,
+  }
+
+  const ticks = generateTicks(
+    engineOptions,
+    totalTicks,
+    timestamps,
+    baseVolume,
+    volumeVolatility,
+  )
+
+  const candles = aggregateToOHLCV(ticks, timeFrame, startTime)
+
+  return {
+    candles,
+    meta: {
+      params: { ...gbmParams, ...jumpParams },
+      startTime,
+      endTime,
+      tickCount: totalTicks,
+      seed,
+    },
+  }
+}

--- a/packages/pyrite/src/prompt.ts
+++ b/packages/pyrite/src/prompt.ts
@@ -1,0 +1,56 @@
+import type { GBMParams, MarketSector, MarketSentiment } from './types'
+import { SECTOR_CONFIGS, SENTIMENT_MULTIPLIERS } from './types'
+
+export interface PromptContext {
+  sector: MarketSector
+  sentiment: MarketSentiment
+  initialPrice?: number
+}
+
+export function buildMacroPrompt(context: PromptContext): string {
+  const { sector, sentiment, initialPrice } = context
+  const sectorConfig = SECTOR_CONFIGS[sector]
+  const sentimentMult = SENTIMENT_MULTIPLIERS[sentiment]
+
+  return `Generate realistic market parameters for ${sector} with ${sentiment} sentiment.
+
+Context:
+- Sector base volatility: ${(sectorConfig.baseVolatility * 100).toFixed(1)}%
+- Sector base drift: ${(sectorConfig.baseDrift * 100).toFixed(1)}%
+- Sentiment drift multiplier: ${sentimentMult.drift}x
+- Sentiment vol multiplier: ${sentimentMult.vol}x
+${initialPrice ? `- Initial price: ${initialPrice}` : ''}
+
+Generate GBM parameters (mu, sigma) suitable for this market condition.
+Return ONLY a JSON object: {"mu": number, "sigma": number}`
+}
+
+export interface MockLLMResponse {
+  mu: number
+  sigma: number
+}
+
+export async function mockLLMGenerate(context: PromptContext): Promise<MockLLMResponse> {
+  const sectorConfig = SECTOR_CONFIGS[context.sector]
+  const sentimentMult = SENTIMENT_MULTIPLIERS[context.sentiment]
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  return {
+    mu: sectorConfig.baseDrift * sentimentMult.drift * (0.9 + Math.random() * 0.2),
+    sigma: sectorConfig.baseVolatility * sentimentMult.vol * (0.9 + Math.random() * 0.2),
+  }
+}
+
+export function resolveParams(
+  context: PromptContext,
+  llmResponse: MockLLMResponse,
+  overrides?: Partial<GBMParams>,
+): GBMParams {
+  return {
+    mu: overrides?.mu ?? llmResponse.mu,
+    sigma: overrides?.sigma ?? llmResponse.sigma,
+    initialPrice: overrides?.initialPrice ?? context.initialPrice ?? 100,
+    dt: overrides?.dt,
+  }
+}

--- a/packages/pyrite/src/types.ts
+++ b/packages/pyrite/src/types.ts
@@ -1,0 +1,128 @@
+import type { CandleData } from '@vulcan-js/core'
+
+export type MarketSector = 'crypto' | 'forex' | 'equity' | 'commodity' | 'custom'
+export type MarketSentiment = 'bullish' | 'bearish' | 'neutral' | 'volatile'
+export type TimeFrame = '1m' | '5m' | '15m' | '30m' | '1h' | '4h' | '1d' | '1w'
+
+export const TIMEFRAME_MS: Record<TimeFrame, number> = {
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '15m': 15 * 60 * 1000,
+  '30m': 30 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '4h': 4 * 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+  '1w': 7 * 24 * 60 * 60 * 1000,
+}
+
+export interface GBMParams {
+  mu: number
+  sigma: number
+  initialPrice: number
+  dt?: number
+}
+
+export interface JumpParams {
+  jumpIntensity: number
+  jumpMean: number
+  jumpVol: number
+}
+
+export interface PriceBoundaries {
+  minPrice: number
+  maxPrice: number
+}
+
+export interface SectorConfig {
+  baseVolatility: number
+  baseDrift: number
+  jumpParams?: JumpParams
+  boundaries: PriceBoundaries
+}
+
+export interface PyriteConfig {
+  sector?: MarketSector
+  sentiment?: MarketSentiment
+  gbm?: Partial<GBMParams>
+  jump?: Partial<JumpParams>
+  boundaries?: Partial<PriceBoundaries>
+  seed?: number
+  useLLM?: boolean
+  llmConfig?: LLMConfig
+}
+
+export interface LLMConfig {
+  provider: 'openai' | 'anthropic' | 'custom'
+  apiKey?: string
+  model?: string
+  baseURL?: string
+  timeout?: number
+}
+
+export interface GenerateOptions {
+  count: number
+  timeFrame?: TimeFrame
+  startTime?: number | Date
+  initialPrice?: number
+  baseVolume?: number
+  volumeVolatility?: number
+}
+
+export interface TickData {
+  price: number
+  volume: number
+  timestamp: number
+}
+
+export interface GenerationResult {
+  candles: CandleData[]
+  meta: {
+    params: GBMParams & Partial<JumpParams>
+    startTime: number
+    endTime: number
+    tickCount: number
+    seed: number
+  }
+}
+
+export interface SeededRandom {
+  next: () => number
+  nextNormal: () => number
+}
+
+export const SECTOR_CONFIGS: Record<MarketSector, SectorConfig> = {
+  crypto: {
+    baseVolatility: 0.8,
+    baseDrift: 0.05,
+    jumpParams: { jumpIntensity: 12, jumpMean: 0, jumpVol: 0.1 },
+    boundaries: { minPrice: 0.000001, maxPrice: 1000000 },
+  },
+  forex: {
+    baseVolatility: 0.1,
+    baseDrift: 0.02,
+    boundaries: { minPrice: 0.1, maxPrice: 1000 },
+  },
+  equity: {
+    baseVolatility: 0.25,
+    baseDrift: 0.08,
+    jumpParams: { jumpIntensity: 4, jumpMean: -0.02, jumpVol: 0.05 },
+    boundaries: { minPrice: 0.01, maxPrice: 100000 },
+  },
+  commodity: {
+    baseVolatility: 0.3,
+    baseDrift: 0.04,
+    boundaries: { minPrice: 1, maxPrice: 10000 },
+  },
+  custom: {
+    baseVolatility: 0.5,
+    baseDrift: 0,
+    boundaries: { minPrice: 0.000001, maxPrice: 10000000 },
+  },
+}
+
+export const SENTIMENT_MULTIPLIERS: Record<MarketSentiment, { drift: number, vol: number }> = {
+  bullish: { drift: 1.5, vol: 0.9 },
+  bearish: { drift: -0.5, vol: 1.2 },
+  neutral: { drift: 1, vol: 1 },
+  volatile: { drift: 0.5, vol: 1.8 },
+}

--- a/packages/pyrite/tests/aggregate.spec.ts
+++ b/packages/pyrite/tests/aggregate.spec.ts
@@ -1,0 +1,120 @@
+import type { TickData, TimeFrame } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { aggregateToOHLCV, generateTimestamps } from '../src/aggregate'
+import { TIMEFRAME_MS } from '../src/types'
+
+describe('aggregateToOHLCV', () => {
+  it('should return empty array for empty ticks', () => {
+    const candles = aggregateToOHLCV([], '1h', Date.now())
+    expect(candles).toEqual([])
+  })
+
+  it('should aggregate single tick into one candle', () => {
+    const startTime = 1000000000000
+    const ticks: TickData[] = [
+      { price: 100, volume: 1000, timestamp: startTime + 1000 },
+    ]
+
+    const candles = aggregateToOHLCV(ticks, '1h', startTime)
+
+    expect(candles.length).toBe(1)
+    expect(candles[0]!.o[0]).toBe(BigInt(100) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.h[0]).toBe(BigInt(100) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.l[0]).toBe(BigInt(100) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.c[0]).toBe(BigInt(100) * BigInt(10) ** BigInt(18))
+  })
+
+  it('should correctly aggregate OHLC values', () => {
+    const startTime = 1000000000000
+    const ticks: TickData[] = [
+      { price: 100, volume: 100, timestamp: startTime + 1000 },
+      { price: 110, volume: 200, timestamp: startTime + 2000 },
+      { price: 90, volume: 150, timestamp: startTime + 3000 },
+      { price: 105, volume: 100, timestamp: startTime + 4000 },
+    ]
+
+    const candles = aggregateToOHLCV(ticks, '1h', startTime)
+
+    expect(candles.length).toBe(1)
+    expect(candles[0]!.o[0]).toBe(BigInt(100) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.h[0]).toBe(BigInt(110) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.l[0]).toBe(BigInt(90) * BigInt(10) ** BigInt(18))
+    expect(candles[0]!.c[0]).toBe(BigInt(105) * BigInt(10) ** BigInt(18))
+  })
+
+  it('should aggregate volume correctly', () => {
+    const startTime = 1000000000000
+    const ticks: TickData[] = [
+      { price: 100, volume: 100, timestamp: startTime + 1000 },
+      { price: 101, volume: 200, timestamp: startTime + 2000 },
+      { price: 102, volume: 300, timestamp: startTime + 3000 },
+    ]
+
+    const candles = aggregateToOHLCV(ticks, '1h', startTime)
+
+    expect(candles.length).toBe(1)
+    expect(candles[0]!.v[0]).toBe(BigInt(600) * BigInt(10) ** BigInt(18))
+  })
+
+  it('should create multiple candles for different time buckets', () => {
+    const startTime = 1000000000000
+    const hourMs = TIMEFRAME_MS['1h']
+    const ticks: TickData[] = [
+      { price: 100, volume: 100, timestamp: startTime + 1000 },
+      { price: 101, volume: 100, timestamp: startTime + hourMs + 1000 },
+      { price: 102, volume: 100, timestamp: startTime + 2 * hourMs + 1000 },
+    ]
+
+    const candles = aggregateToOHLCV(ticks, '1h', startTime)
+
+    expect(candles.length).toBe(3)
+  })
+
+  it('should set correct timestamps on candles', () => {
+    const startTime = 1000000000000
+    const hourMs = TIMEFRAME_MS['1h']
+    const ticks: TickData[] = [
+      { price: 100, volume: 100, timestamp: startTime + 1000 },
+      { price: 101, volume: 100, timestamp: startTime + hourMs + 1000 },
+    ]
+
+    const candles = aggregateToOHLCV(ticks, '1h', startTime)
+
+    expect(candles[0]!.timestamp).toBe(startTime)
+    expect(candles[1]!.timestamp).toBe(startTime + hourMs)
+  })
+})
+
+describe('generateTimestamps', () => {
+  it('should generate correct number of timestamps', () => {
+    const startTime = 1000000000000
+    const timestamps = generateTimestamps(10, '1h', startTime)
+
+    expect(timestamps.length).toBe(10)
+  })
+
+  it('should generate timestamps in ascending order', () => {
+    const startTime = 1000000000000
+    const timestamps = generateTimestamps(10, '1h', startTime)
+
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]).toBeGreaterThan(timestamps[i - 1]!)
+    }
+  })
+
+  it('should respect timeframe interval', () => {
+    const startTime = 1000000000000
+    const count = 5
+    const timeFrame: TimeFrame = '1h'
+    const interval = TIMEFRAME_MS[timeFrame]
+
+    const timestamps = generateTimestamps(count, timeFrame, startTime)
+
+    const firstTimestamp = timestamps[0]!
+    const lastTimestamp = timestamps[timestamps.length - 1]!
+    const span = lastTimestamp - firstTimestamp
+
+    expect(span).toBeGreaterThanOrEqual((count - 1) * interval * 0.5)
+    expect(span).toBeLessThan(count * interval)
+  })
+})

--- a/packages/pyrite/tests/gbm.spec.ts
+++ b/packages/pyrite/tests/gbm.spec.ts
@@ -1,0 +1,195 @@
+import type { GBMParams, JumpParams, PriceBoundaries } from '../src/types'
+import { describe, expect, it } from 'vitest'
+import { createGBMEngine, generateTicks, Mulberry32 } from '../src/gbm'
+
+describe('mulberry32', () => {
+  it('should generate reproducible random numbers with same seed', () => {
+    const rng1 = new Mulberry32(12345)
+    const rng2 = new Mulberry32(12345)
+
+    const values1 = Array.from({ length: 10 }, () => rng1.next())
+    const values2 = Array.from({ length: 10 }, () => rng2.next())
+
+    expect(values1).toEqual(values2)
+  })
+
+  it('should generate different sequences with different seeds', () => {
+    const rng1 = new Mulberry32(12345)
+    const rng2 = new Mulberry32(54321)
+
+    const values1 = Array.from({ length: 10 }, () => rng1.next())
+    const values2 = Array.from({ length: 10 }, () => rng2.next())
+
+    expect(values1).not.toEqual(values2)
+  })
+
+  it('should generate values in [0, 1) range', () => {
+    const rng = new Mulberry32(12345)
+
+    for (let i = 0; i < 100; i++) {
+      const value = rng.next()
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThan(1)
+    }
+  })
+
+  it('should generate normal distribution values', () => {
+    const rng = new Mulberry32(12345)
+    const values = Array.from({ length: 1000 }, () => rng.nextNormal())
+
+    const mean = values.reduce((a, b) => a + b, 0) / values.length
+    const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length
+
+    expect(mean).toBeCloseTo(0, 1)
+    expect(Math.sqrt(variance)).toBeCloseTo(1, 0)
+  })
+})
+
+describe('createGBMEngine', () => {
+  const baseParams: GBMParams = {
+    mu: 0.1,
+    sigma: 0.2,
+    initialPrice: 100,
+  }
+
+  const boundaries: PriceBoundaries = {
+    minPrice: 1,
+    maxPrice: 10000,
+  }
+
+  it('should generate prices starting near initial price', () => {
+    const rng = new Mulberry32(12345)
+    const engine = createGBMEngine({
+      gbm: baseParams,
+      boundaries,
+      rng,
+    })
+
+    const prices = Array.from({ length: 10 }, () => engine.nextPrice())
+
+    expect(prices[0]).toBeGreaterThan(50)
+    expect(prices[0]).toBeLessThan(150)
+  })
+
+  it('should respect price boundaries', () => {
+    const rng = new Mulberry32(12345)
+    const tightBoundaries: PriceBoundaries = {
+      minPrice: 90,
+      maxPrice: 110,
+    }
+
+    const engine = createGBMEngine({
+      gbm: baseParams,
+      boundaries: tightBoundaries,
+      rng,
+    })
+
+    for (let i = 0; i < 100; i++) {
+      const price = engine.nextPrice()
+      expect(price).toBeGreaterThanOrEqual(tightBoundaries.minPrice)
+      expect(price).toBeLessThanOrEqual(tightBoundaries.maxPrice)
+    }
+  })
+
+  it('should be resettable', () => {
+    const rng = new Mulberry32(12345)
+    const engine = createGBMEngine({
+      gbm: baseParams,
+      boundaries,
+      rng,
+    })
+
+    const price1 = engine.nextPrice()
+    engine.reset()
+    const price2 = engine.nextPrice()
+
+    expect(price1).toBe(price2)
+  })
+
+  it('should apply jumps when jump params provided', () => {
+    const rng = new Mulberry32(12345)
+    const jumpParams: JumpParams = {
+      jumpIntensity: 1000,
+      jumpMean: 0,
+      jumpVol: 0.1,
+    }
+
+    const engine = createGBMEngine({
+      gbm: baseParams,
+      jump: jumpParams,
+      boundaries,
+      rng,
+    })
+
+    const prices = Array.from({ length: 100 }, () => engine.nextPrice())
+    const priceChanges = prices.slice(1).map((p, i) => Math.abs(p - prices[i]!))
+    const maxChange = Math.max(...priceChanges)
+
+    expect(maxChange).toBeGreaterThan(10)
+  })
+})
+
+describe('generateTicks', () => {
+  const baseParams: GBMParams = {
+    mu: 0.1,
+    sigma: 0.2,
+    initialPrice: 100,
+  }
+
+  const boundaries: PriceBoundaries = {
+    minPrice: 1,
+    maxPrice: 10000,
+  }
+
+  it('should generate correct number of ticks', () => {
+    const rng = new Mulberry32(12345)
+    const count = 50
+    const timestamps = Array.from({ length: count }, (_, i) => 1000000 + i * 1000)
+
+    const ticks = generateTicks(
+      { gbm: baseParams, boundaries, rng },
+      count,
+      timestamps,
+      1000,
+      0.5,
+    )
+
+    expect(ticks.length).toBe(count)
+  })
+
+  it('should generate positive volumes', () => {
+    const rng = new Mulberry32(12345)
+    const count = 10
+    const timestamps = Array.from({ length: count }, (_, i) => 1000000 + i * 1000)
+
+    const ticks = generateTicks(
+      { gbm: baseParams, boundaries, rng },
+      count,
+      timestamps,
+      1000,
+      0.5,
+    )
+
+    for (const tick of ticks) {
+      expect(tick.volume).toBeGreaterThan(0)
+    }
+  })
+
+  it('should respect provided timestamps', () => {
+    const rng = new Mulberry32(12345)
+    const count = 10
+    const timestamps = Array.from({ length: count }, (_, i) => 1000000 + i * 1000)
+
+    const ticks = generateTicks(
+      { gbm: baseParams, boundaries, rng },
+      count,
+      timestamps,
+      1000,
+      0.5,
+    )
+
+    for (let i = 0; i < count; i++) {
+      expect(ticks[i]!.timestamp).toBe(timestamps[i])
+    }
+  })
+})

--- a/packages/pyrite/tests/index.spec.ts
+++ b/packages/pyrite/tests/index.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { generate, generateSync } from '../src/index'
+
+describe('generateSync', () => {
+  it('should generate correct number of candles', () => {
+    const result = generateSync(
+      { sector: 'crypto', seed: 12345 },
+      { count: 10, timeFrame: '1h' },
+    )
+
+    expect(result.candles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should be reproducible with same seed', () => {
+    const result1 = generateSync(
+      { sector: 'crypto', seed: 12345 },
+      { count: 10, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    const result2 = generateSync(
+      { sector: 'crypto', seed: 12345 },
+      { count: 10, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    expect(result1.candles.length).toBe(result2.candles.length)
+    for (let i = 0; i < result1.candles.length; i++) {
+      expect(result1.candles[i]!.o[0]).toBe(result2.candles[i]!.o[0])
+      expect(result1.candles[i]!.h[0]).toBe(result2.candles[i]!.h[0])
+      expect(result1.candles[i]!.l[0]).toBe(result2.candles[i]!.l[0])
+      expect(result1.candles[i]!.c[0]).toBe(result2.candles[i]!.c[0])
+    }
+  })
+
+  it('should generate different data with different seeds', () => {
+    const result1 = generateSync(
+      { sector: 'crypto', seed: 12345 },
+      { count: 10, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    const result2 = generateSync(
+      { sector: 'crypto', seed: 54321 },
+      { count: 10, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    const hasDifference = result1.candles.some((c, i) => {
+      const c2 = result2.candles[i]
+      if (!c2)
+        return true
+      return c.o[0] !== c2.o[0] || c.c[0] !== c2.c[0]
+    })
+
+    expect(hasDifference).toBe(true)
+  })
+
+  it('should include metadata', () => {
+    const result = generateSync(
+      { sector: 'crypto', seed: 12345 },
+      { count: 10, timeFrame: '1h' },
+    )
+
+    expect(result.meta).toBeDefined()
+    expect(result.meta.params).toBeDefined()
+    expect(typeof result.meta.params.mu).toBe('number')
+    expect(typeof result.meta.params.sigma).toBe('number')
+    expect(result.meta.seed).toBe(12345)
+    expect(result.meta.tickCount).toBeGreaterThan(0)
+  })
+
+  it('should respect custom GBM parameters', () => {
+    const result = generateSync(
+      {
+        sector: 'custom',
+        gbm: { mu: 0.5, sigma: 0.1, initialPrice: 500 },
+        seed: 12345,
+      },
+      { count: 10, timeFrame: '1h' },
+    )
+
+    expect(result.meta.params.mu).toBe(0.5)
+    expect(result.meta.params.sigma).toBe(0.1)
+  })
+
+  it('should generate candles with valid OHLCV structure', () => {
+    const result = generateSync(
+      { sector: 'forex', seed: 12345 },
+      { count: 5, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    for (const candle of result.candles) {
+      expect(candle.o).toBeDefined()
+      expect(candle.h).toBeDefined()
+      expect(candle.l).toBeDefined()
+      expect(candle.c).toBeDefined()
+      expect(candle.v).toBeDefined()
+      expect(candle.h[0]).toBeGreaterThanOrEqual(candle.l[0])
+      expect(candle.h[0]).toBeGreaterThanOrEqual(candle.o[0])
+      expect(candle.h[0]).toBeGreaterThanOrEqual(candle.c[0])
+      expect(candle.l[0]).toBeLessThanOrEqual(candle.o[0])
+      expect(candle.l[0]).toBeLessThanOrEqual(candle.c[0])
+    }
+  })
+})
+
+describe('generate', () => {
+  it('should generate candles asynchronously', async () => {
+    const result = await generate(
+      { sector: 'equity', seed: 12345 },
+      { count: 10, timeFrame: '1h' },
+    )
+
+    expect(result.candles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should work with LLM mode (mock)', async () => {
+    const result = await generate(
+      { sector: 'crypto', seed: 12345, useLLM: true },
+      { count: 10, timeFrame: '1h', initialPrice: 100 },
+    )
+
+    expect(result.candles.length).toBeGreaterThanOrEqual(1)
+    expect(result.meta.params.mu).toBeDefined()
+    expect(result.meta.params.sigma).toBeDefined()
+  })
+})

--- a/packages/pyrite/tsconfig.json
+++ b/packages/pyrite/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@vulcan-js/core": ["../core/src/index.ts"],
+      "@vulcan-js/pyrite": ["./src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "tests/**/*.spec.ts"]
+}


### PR DESCRIPTION
Add new package for generating synthetic OHLCV market data using GBM and Jump Diffusion models.

## Features
- Geometric Brownian Motion (GBM) for price simulation
- Jump Diffusion for realistic market jumps
- Industry-specific volatility profiles (crypto, forex, equity, commodity)
- Market sentiment multipliers
- Seed-based reproducibility
- Multiple timeframe support (1m to 1w)
- Sync and async generate functions

## Technical Details
- GBM engine with configurable drift and volatility
- OHLCV aggregation from tick-level data
- Mock LLM integration for parameter generation
- Comprehensive test suite

## Usage
```ts
import { generate } from '@vulcan-js/pyrite'

const candles = await generate({
  sector: 'crypto',
  sentiment: 'bullish',
  count: 100,
  timeframe: '1h',
  seed: 42,
})
```

Resolves #30