### PR TITLE
feat(indicators): add Force Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const result3 = process(98)
 - [x] Accumulation/Distribution (AD)
 - [x] On-Balance Volume (OBV)
 - [x] Volume Weighted Average Price (VWAP)
-- [ ] Force Index
+- [x] Force Index
 - [x] Ease of Movement (EOM)
 
 ## License

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,7 +128,7 @@ const result3 = process(98)
 - [x] Accumulation/Distribution (AD)
 - [x] On-Balance Volume (OBV)
 - [x] Volume Weighted Average Price (VWAP)
-- [ ] Force Index
+- [x] Force Index
 - [x] Ease of Movement (EOM)
 
 ## License

--- a/packages/indicators/src/volume/force-index.ts
+++ b/packages/indicators/src/volume/force-index.ts
@@ -1,0 +1,69 @@
+import type { CandleData, RequiredProperties } from '@vulcan-js/core'
+import { assert, createSignal, fp18 } from '@vulcan-js/core'
+import * as prim from '../primitives'
+
+export interface ForceIndexOptions {
+  /**
+   * The EMA smoothing period for Force Index.
+   * @default 13
+   */
+  period: number
+}
+
+export const defaultForceIndexOptions: ForceIndexOptions = {
+  period: 13,
+}
+
+/**
+ * Force Index
+ *
+ * A technical indicator that measures the amount of power used to move the price
+ * of an asset. It combines price change and volume to assess the force behind
+ * price movements. Positive values indicate buying pressure, negative values
+ * indicate selling pressure.
+ *
+ * Formula:
+ *   Raw Force Index = (Current Close - Prior Close) × Volume
+ *   Force Index = EMA(Raw Force Index, period)
+ *
+ * @param source - Iterable of OHLCV candle data (requires close and volume)
+ * @param options - Configuration options
+ * @param options.period - The EMA smoothing period (default: 13)
+ * @returns Generator yielding Force Index values as Dnum tuples
+ *
+ * @example
+ * ```ts
+ * const fiValues = collect(forceIndex(candles))
+ * // Each value is a Dnum tuple: [bigint, number]
+ * ```
+ */
+export const forceIndex = createSignal(
+  ({ period }) => {
+    assert(Number.isInteger(period) && period > 0, new RangeError(`Expected period to be a positive integer, got ${period}`))
+
+    const ema = prim.ema({ period })
+    let prevClose: bigint | undefined
+
+    return (bar: RequiredProperties<CandleData, 'c' | 'v'>): readonly [bigint, number] => {
+      const close = fp18.toFp18(bar.c)
+      const volume = fp18.toFp18(bar.v)
+
+      let rawFI = fp18.ZERO
+
+      if (prevClose !== undefined) {
+        // Raw Force Index = (Close - Prior Close) × Volume
+        const priceChange = close - prevClose
+        rawFI = fp18.mul(priceChange, volume)
+      }
+
+      prevClose = close
+
+      // Apply EMA smoothing
+      const smoothedFI = ema(rawFI)
+      return fp18.toDnum(smoothedFI)
+    }
+  },
+  defaultForceIndexOptions,
+)
+
+export { forceIndex as fi }

--- a/packages/indicators/src/volume/index.ts
+++ b/packages/indicators/src/volume/index.ts
@@ -1,5 +1,6 @@
 export * from './accumulationDistribution'
 export * from './easeOfMovement'
+export * from './force-index'
 export * from './mfi'
 export * from './on-balance-volume'
 export * from './vwap'

--- a/packages/indicators/tests/volume/force-index.spec.ts
+++ b/packages/indicators/tests/volume/force-index.spec.ts
@@ -1,0 +1,128 @@
+import { collect } from '@vulcan-js/core'
+import { fi, forceIndex } from '@vulcan-js/indicators'
+import { describe, expect, it } from 'vitest'
+
+describe('force index (FI)', () => {
+  // OHLCV candle data for testing
+  const candles = [
+    { h: 10.0, l: 8.0, c: 9.0, v: 1000 },
+    { h: 11.0, l: 9.0, c: 10.0, v: 2000 },
+    { h: 12.0, l: 10.0, c: 11.0, v: 1500 },
+    { h: 11.5, l: 9.5, c: 10.5, v: 800 },
+    { h: 11.0, l: 9.0, c: 10.0, v: 1200 },
+  ]
+
+  it('should calculate Force Index with default period (13)', () => {
+    const result = collect(forceIndex(candles))
+
+    expect(result).toHaveLength(candles.length)
+
+    // First bar has no prior close, so FI should be 0
+    expect(Number(result[0][0])).toBe(0)
+
+    // All values should be valid numbers
+    for (const val of result) {
+      expect(Number.isFinite(Number(val[0]))).toBe(true)
+    }
+  })
+
+  it('should calculate Force Index with custom period', () => {
+    const result = collect(forceIndex(candles, { period: 3 }))
+
+    expect(result).toHaveLength(candles.length)
+
+    for (const val of result) {
+      expect(Number.isFinite(Number(val[0]))).toBe(true)
+    }
+  })
+
+  it('should produce positive Force Index during uptrend', () => {
+    const uptrend = [
+      { h: 10.0, l: 8.0, c: 9.0, v: 1000 },
+      { h: 12.0, l: 10.0, c: 11.0, v: 1000 },
+      { h: 14.0, l: 12.0, c: 13.0, v: 1000 },
+      { h: 16.0, l: 14.0, c: 15.0, v: 1000 },
+      { h: 18.0, l: 16.0, c: 17.0, v: 1000 },
+    ]
+
+    const result = collect(forceIndex(uptrend))
+
+    // After initial bars, FI should be positive during uptrend
+    const lastFI = Number(result[result.length - 1][0]) / 10 ** result[result.length - 1][1]
+    expect(lastFI).toBeGreaterThan(0)
+  })
+
+  it('should produce negative Force Index during downtrend', () => {
+    const downtrend = [
+      { h: 18.0, l: 16.0, c: 17.0, v: 1000 },
+      { h: 16.0, l: 14.0, c: 15.0, v: 1000 },
+      { h: 14.0, l: 12.0, c: 13.0, v: 1000 },
+      { h: 12.0, l: 10.0, c: 11.0, v: 1000 },
+      { h: 10.0, l: 8.0, c: 9.0, v: 1000 },
+    ]
+
+    const result = collect(forceIndex(downtrend))
+
+    // After initial bars, FI should be negative during downtrend
+    const lastFI = Number(result[result.length - 1][0]) / 10 ** result[result.length - 1][1]
+    expect(lastFI).toBeLessThan(0)
+  })
+
+  it('should work with stateful processor via .create()', () => {
+    const process = forceIndex.create({ period: 13 })
+
+    const results: Array<readonly [bigint, number]> = []
+    for (const candle of candles) {
+      results.push(process(candle))
+    }
+
+    expect(results).toHaveLength(candles.length)
+
+    for (const val of results) {
+      expect(Number.isFinite(Number(val[0]))).toBe(true)
+    }
+  })
+
+  it('should work with fi alias', () => {
+    const result1 = collect(forceIndex(candles))
+    const result2 = collect(fi(candles))
+
+    expect(result1).toEqual(result2)
+  })
+
+  it('should throw for invalid period', () => {
+    expect(() => collect(forceIndex(candles, { period: 0 }))).toThrow(RangeError)
+    expect(() => collect(forceIndex(candles, { period: -1 }))).toThrow(RangeError)
+    expect(() => collect(forceIndex(candles, { period: 1.5 }))).toThrow(RangeError)
+  })
+
+  it('should calculate correct Force Index values manually', () => {
+    // Simple case: price up with volume
+    const simpleCandles = [
+      { h: 10.0, l: 8.0, c: 9.0, v: 1000 },
+      { h: 11.0, l: 9.0, c: 10.0, v: 2000 }, // +1 price change, 2000 volume = 2000 raw FI
+    ]
+
+    const result = collect(forceIndex(simpleCandles))
+
+    // First bar: FI = 0 (no prior close)
+    expect(Number(result[0][0])).toBe(0)
+
+    // Second bar: FI should be positive
+    const secondFI = Number(result[1][0]) / 10 ** result[1][1]
+    expect(secondFI).toBeGreaterThan(0)
+  })
+
+  it('should handle zero volume', () => {
+    const zeroVolCandles = [
+      { h: 10.0, l: 8.0, c: 9.0, v: 1000 },
+      { h: 11.0, l: 9.0, c: 10.0, v: 0 }, // price up but zero volume
+    ]
+
+    const result = collect(forceIndex(zeroVolCandles))
+
+    // Second bar: FI should be 0 (zero volume means no force)
+    const secondFI = Number(result[1][0]) / 10 ** result[1][1]
+    expect(secondFI).toBe(0)
+  })
+})


### PR DESCRIPTION
Implements the Force Index (FI) volume-based oscillator.

## Changes
- Add Force Index measuring buying/selling pressure
- Raw FI = (Close - Prior Close) × Volume
- EMA smoothed with configurable period (default 13)
- Positive values indicate buying pressure, negative values selling pressure
- Full test coverage including trend detection and edge cases

## Technical Details
- Generator-based streaming with `.create()` stateful processor
- High-precision decimal arithmetic via dnum/fp18
- Includes `forceIndex` and `fi` exports

## Checklist
- [x] Implementation
- [x] Unit tests
- [x] Export in index.ts
- [x] README updated
- [x] README_zh updated