### PR TITLE
docs: mark Standard Deviation as completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const result3 = process(98)
 - [x] Bollinger Bands
 - [x] Keltner Channels
 - [x] Donchian Channels
-- [ ] Standard Deviation
+- [x] Standard Deviation
 
 ### Volume
 


### PR DESCRIPTION
Standard Deviation indicator was already implemented in `packages/indicators/src/volatility/standardDeviation.ts`.

This PR updates the README to reflect the completed status.